### PR TITLE
Fix paketPack task creation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     post {
         always {
             sendSlackNotification currentBuild.result, true
-            junit allowEmptyResults: true, testResults: 'build/test-result/**/*.xml'
+            junit allowEmptyResults: true, testResults: 'build/test-results/**/*.xml'
             gradleWrapper "clean"
         }
     }

--- a/src/integrationTest/groovy/wooga/gradle/paket/pack/PaketPackIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/pack/PaketPackIntegrationSpec.groovy
@@ -70,4 +70,28 @@ class PaketPackIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         where:
         taskToRun << ["paketPack-WoogaTest", "buildNupkg", "assemble"]
     }
+
+    @Unroll
+    def "can depend on generated pack tasks #taskToRun"(String taskToRun)  {
+        given: "the build.gradle with second task that must run before packetPack"
+        buildFile << """
+            task(preStep) {
+                doLast {
+                    println("execute pre step")
+                }
+            }
+            
+            project.tasks["paketPack-WoogaTest"].dependsOn preStep
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        result.wasExecuted("paketPack-WoogaTest")
+        result.wasExecuted("preStep")
+
+        where:
+        taskToRun << ["paketPack-WoogaTest", "buildNupkg", "assemble"]
+    }
 }

--- a/src/main/groovy/wooga/gradle/paket/base/PaketBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/PaketBasePlugin.groovy
@@ -58,9 +58,8 @@ class PaketBasePlugin implements Plugin<Project> {
         init.finalizedBy paketBootstrap
 
         def configurations = project.configurations
-        configurations.create(PAKET_CONFIGURATION) {
-            description = "paket nupkg archive"
-            transitive = false
-        }
+        def configuration = configurations.maybeCreate(PAKET_CONFIGURATION)
+        configuration.description = "paket nupkg archive"
+        configuration.transitive = false
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -46,29 +46,25 @@ class PaketPackPlugin implements Plugin<Project> {
         def paketBootstrap = tasks[PaketBasePlugin.BOOTSTRAP_TASK_NAME]
         def extension = project.extensions.getByType(DefaultPaketPluginExtension)
 
-        project.afterEvaluate {
-            def templateFiles = project.fileTree(project.projectDir)
-            templateFiles.include PAKET_TEMPLATE_PATTERN
-            templateFiles.each { File file ->
-                def templateReader = new PaketTemplateReader(file)
-                def packageID = templateReader.getPackageId()
-                def packageName = packageID.replaceAll(/\./, '')
-                def packTask = tasks.create(TASK_PACK_PREFIX + packageName, PaketPack.class)
+        def templateFiles = project.fileTree(project.projectDir)
+        templateFiles.include PAKET_TEMPLATE_PATTERN
+        templateFiles.each { File file ->
+            def templateReader = new PaketTemplateReader(file)
+            def packageID = templateReader.getPackageId()
+            def packageName = packageID.replaceAll(/\./, '')
+            def packTask = tasks.create(TASK_PACK_PREFIX + packageName, PaketPack.class)
 
-                packTask.group = BasePlugin.BUILD_GROUP
-                packTask.templateFile = file
-                packTask.outputDir = project.file("${project.buildDir}/outputs")
-                packTask.version = project.version
-                packTask.description = "Pack package ${templateReader.getPackageId()}"
-                packTask.paketExtension = extension
-                packTask.dependsOn paketBootstrap
+            packTask.group = BasePlugin.BUILD_GROUP
+            packTask.templateFile = file
+            packTask.outputDir = project.file("${project.buildDir}/outputs")
+            packTask.version = project.version
+            packTask.description = "Pack package ${templateReader.getPackageId()}"
+            packTask.paketExtension = extension
+            packTask.dependsOn paketBootstrap
 
-                tasks[BasePlugin.ASSEMBLE_TASK_NAME].dependsOn packTask
+            tasks[BasePlugin.ASSEMBLE_TASK_NAME].dependsOn packTask
 
-                project.artifacts.add(PaketBasePlugin.PAKET_CONFIGURATION, [file: packTask.outputFile, name: packageID, builtBy: packTask])
-            }
-
-            configurePaketInstallIfPresent()
+            project.artifacts.add(PaketBasePlugin.PAKET_CONFIGURATION, [file: packTask.outputFile, name: packageID, builtBy: packTask])
         }
     }
 
@@ -98,4 +94,5 @@ class PaketPackPlugin implements Plugin<Project> {
             content['id']
         }
     }
+
 }

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -66,6 +66,8 @@ class PaketPackPlugin implements Plugin<Project> {
 
             project.artifacts.add(PaketBasePlugin.PAKET_CONFIGURATION, [file: packTask.outputFile, name: packageID, builtBy: packTask])
         }
+
+        configurePaketInstallIfPresent()
     }
 
     void configurePaketInstallIfPresent() {

--- a/src/test/groovy/wooga/gradle/paket/pack/PaketPackPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/pack/PaketPackPluginSpec.groovy
@@ -59,16 +59,13 @@ class PaketPackPluginSpec extends ProjectSpec {
         !project.tasks.withType(PaketPack)
     }
 
-    def "creates pack task after evaluation"() {
-        given: "project with plugin applied"
-        project.pluginManager.apply(PLUGIN_NAME)
-
-        and: "one paket template file in the file system"
+    def "creates pack task when paket.template in the project tree"() {
+        given: "one paket template file in the project file system"
         projectWithPaketTemplate(projectDir)
         assert !project.tasks.withType(PaketPack)
 
-        when:
-        project.evaluate()
+        when: "applying paket-pack plugin"
+        project.pluginManager.apply(PLUGIN_NAME)
 
         then:
         def tasks = project.tasks.withType(PaketPack)
@@ -77,15 +74,12 @@ class PaketPackPluginSpec extends ProjectSpec {
     }
 
     def "creates pack tasks for template files in sub directories"() {
-        given: "project with plugin applied"
-        project.pluginManager.apply(PLUGIN_NAME)
-
-        and: "one paket template file in subdirectory in the file system"
+        given: "one paket template file in subdirectory in the file system"
         projectWithPaketTemplates(["Test.Package"])
         assert !project.tasks.withType(PaketPack)
 
-        when:
-        project.evaluate()
+        when: "applying paket-pack plugin"
+        project.pluginManager.apply(PLUGIN_NAME)
 
         then:
         def tasks = project.tasks.withType(PaketPack)
@@ -97,12 +91,8 @@ class PaketPackPluginSpec extends ProjectSpec {
         given: "some paket template files in the file system"
         projectWithPaketTemplates(["Test.Package1", "Test.Package2", "Test.Package3"])
 
-        and: "project with plugin applied"
+        when: "applying paket-pack plugin"
         project.pluginManager.apply(PLUGIN_NAME)
-        assert !project.tasks.withType(PaketPack)
-
-        when:
-        project.evaluate()
 
         then:
         def tasks = project.tasks.withType(PaketPack)
@@ -113,15 +103,12 @@ class PaketPackPluginSpec extends ProjectSpec {
     }
 
     def "adds artifact to configuration [nupkg]"() {
-        given: "project with plugin applied"
-        project.pluginManager.apply(PLUGIN_NAME)
-
-        and: "some paket template files in the file system"
+        given: "some paket template files in the file system"
         projectWithPaketTemplates(["Test.Package1", "Test.Package2", "Test.Package3"])
-        assert !project.configurations[PaketBasePlugin.PAKET_CONFIGURATION].allArtifacts
+        assert !project.configurations.maybeCreate(PaketBasePlugin.PAKET_CONFIGURATION).allArtifacts
 
-        when:
-        project.evaluate()
+        when: "applying paket-pack plugin"
+        project.pluginManager.apply(PLUGIN_NAME)
 
         then:
         def artifacts = project.configurations[PaketBasePlugin.PAKET_CONFIGURATION].allArtifacts


### PR DESCRIPTION
Create all `paketPack` tasks when applying the plugin so users can refer
to the generated tasks at configuration time.

Adjust test specs

fixes #1 