### PR TITLE
Add gradle version support tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,18 @@ Gradle and Java Compatibility
 Built with Oracle JDK7
 Tested with Oracle JDK8
 
-| Gradle Version | Works |
-| :------------: | :---: |
-| 3.4.1          | yes   |
-| 3.5            | yes   |
+| Gradle Version | Works       |
+| :------------- | :---------: |
+| <= 2.13        | ![no]       |
+| 2.14           | ![yes]      |
+| 3.0            | ![yes]      |
+| 3.1            | ![yes]      |
+| 3.2            | ![yes]      |
+| 3.4            | ![yes]      |
+| 3.4.1          | ![yes]      |
+| 3.5            | ![yes]      |
+| 3.5.1          | ![yes]      |
+| 4.0            | ![yes]      |
 
 LICENSE
 =======
@@ -208,4 +216,8 @@ limitations under the License.
 [gradle]:               https://gradle.org/ "Gradle"
 [gradle_finalizedBy]:   https://docs.gradle.org/3.5/dsl/org.gradle.api.Task.html#org.gradle.api.Task:finalizedBy
 [gradle_dependsOn]:     https://docs.gradle.org/3.5/dsl/org.gradle.api.Task.html#org.gradle.api.Task:dependsOn
+
+[yes]:                  http://atlas-resources.wooga.com/icons/icon_check.svg "yes"
+[no]:                   http://atlas-resources.wooga.com/icons/icon_uncheck.svg "no"
+
 

--- a/src/integrationTest/groovy/wooga/gradle/paket/TestFixtures.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/TestFixtures.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket
+
+class TestFixtures {
+    static List<String> gradleVersions() {
+        ["2.14", "3.0", "3.1", "3.2", "3.4", "3.4.1", "3.5", "3.5.1", "4.0"]
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.paket.get
 import spock.lang.Ignore
 import spock.lang.Unroll
 import wooga.gradle.paket.PaketIntegrationDependencyFileSpec
+import wooga.gradle.paket.TestFixtures
 
 class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
 
@@ -85,5 +86,27 @@ class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
 
         where:
         taskToRun << bootstrapTestCases
+    }
+
+    @Unroll("verify paket install with gradle #gradleVersionToTest")
+    def "runs plugin with multiple gradle versions"() {
+        given: "empty paket dependency file and lock"
+        createFile("paket.dependencies")
+        createFile("paket.lock")
+
+        gradleVersion = gradleVersionToTest
+
+        expect:
+        runTasksSuccessfully("paketInstall")
+
+        where:
+        gradleVersionToTest << TestFixtures.gradleVersions()
+    }
+
+
+    @Ignore
+    @Unroll
+    def "Increment task #taskToRun"(String taskToRun) {
+
     }
 }


### PR DESCRIPTION
The spec files `PaketIntallIntegrationSpec` and
`PaketPublishIntegrationSpec` will test against a list of gradle
versions.

Document supported versions in README