### PR TITLE
Fix plugin crash when duplicate paket.template ids in file tree

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
@@ -22,7 +22,7 @@ import nebula.test.functional.ExecutionResult
 import spock.lang.Shared
 import spock.lang.Unroll
 
-abstract class PaketIntegrationBaseSpec extends IntegrationSpec{
+abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
 
     @Shared
     def bootstrapTestCases
@@ -76,12 +76,12 @@ abstract class PaketIntegrationBaseSpec extends IntegrationSpec{
         then: "bootstrap task was [UP-TO-DATE]"
         result.wasUpToDate(bootstrapTaskName)
 
-        when:"delete bootstrapper"
+        when: "delete bootstrapper"
         def paketDir = new File(projectDir, '.paket')
         def paketBootstrap = new File(paketDir, bootstrapperFileName)
         paketBootstrap.delete()
 
-        and:"run the task again"
+        and: "run the task again"
         def result2 = runTasksSuccessfully(taskToRun)
 
         then:
@@ -97,5 +97,22 @@ abstract class PaketIntegrationBaseSpec extends IntegrationSpec{
 
     private boolean containsOutput(String stdout, String taskName, String stateIdentifier) {
         stdout.contains("$taskName $stateIdentifier".toString())
+    }
+
+    def projectWithPaketTemplates(ids) {
+        def files = []
+        ids.each { String id ->
+            def subDirectory = new File(projectDir, id)
+            subDirectory.mkdirs()
+            files << projectWithPaketTemplate(subDirectory, id)
+        }
+        files
+    }
+
+    def projectWithPaketTemplate(File directory, String id = "Test.Package") {
+        def templateFile = new File(directory, "paket.template")
+        templateFile.createNewFile()
+        templateFile.append("id $id")
+        templateFile
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -52,7 +52,7 @@ class PaketPackPlugin implements Plugin<Project> {
 
         def templateFiles = project.fileTree(project.projectDir)
         templateFiles.include PAKET_TEMPLATE_PATTERN
-        templateFiles.sort()
+        templateFiles = templateFiles.sort()
         templateFiles = templateFiles.sort(true, new Comparator<File>() {
             @Override
             int compare(File o1, File o2) {

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -19,6 +19,8 @@ package wooga.gradle.paket.pack
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.tasks.TaskContainer
 import wooga.gradle.paket.base.DefaultPaketPluginExtension
@@ -27,6 +29,8 @@ import wooga.gradle.paket.get.PaketGetPlugin
 import wooga.gradle.paket.pack.tasks.PaketPack
 
 class PaketPackPlugin implements Plugin<Project> {
+
+    static Logger logger = Logging.getLogger(PaketPackPlugin)
 
     Project project
     TaskContainer tasks
@@ -52,7 +56,14 @@ class PaketPackPlugin implements Plugin<Project> {
             def templateReader = new PaketTemplateReader(file)
             def packageID = templateReader.getPackageId()
             def packageName = packageID.replaceAll(/\./, '')
-            def packTask = tasks.create(TASK_PACK_PREFIX + packageName, PaketPack.class)
+            def taskName = TASK_PACK_PREFIX + packageName
+
+            if (tasks.findByName(taskName)) {
+                logger.warn("Multiple paket.template files with id ${packageID}. Skip template file at: $file.path")
+                return
+            }
+
+            def packTask = tasks.create(taskName, PaketPack.class)
 
             packTask.group = BasePlugin.BUILD_GROUP
             packTask.templateFile = file

--- a/src/test/groovy/wooga/gradle/paket/pack/PaketPackPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/pack/PaketPackPluginSpec.groovy
@@ -103,6 +103,19 @@ class PaketPackPluginSpec extends ProjectSpec {
         tasks.every { it.dependsOn.contains(project.tasks[PaketBasePlugin.BOOTSTRAP_TASK_NAME]) }
     }
 
+    def "skips pack task creation for duplicate package id"() {
+        given: "some paket template files in the file system with same id"
+        projectWithPaketTemplate(projectDir,"Test.Package1")
+        projectWithPaketTemplates(["Test.Package1"])
+
+        when: "applying paket-pack plugin"
+        project.pluginManager.apply(PLUGIN_NAME)
+
+        then:
+        def tasks = project.tasks.withType(PaketPack)
+        tasks.size() == 1
+    }
+
     def "adds artifact to configuration [nupkg]"() {
         given: "some paket template files in the file system"
         projectWithPaketTemplates(["Test.Package1", "Test.Package2", "Test.Package3"])


### PR DESCRIPTION
Each paket.template file in the file tree is spawning a new `PaketPack`
task. This commit handles situation when multiple paket.template files
with the same `id` are location in the file tree.

The plugin will only create one task and skips any other task creation
if a pack task with the same name was already created.