### PR TITLE
Fix lazy project version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+out/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: java
 
 matrix:
   include:
-    - os: linux
-      sudo: true
-      jdk: oraclejdk8
-    - os: linux
-      sudo: true
-      jdk: oraclejdk7
+    # - os: linux
+    #   sudo: true
+    #   jdk: oraclejdk8
+    # - os: linux
+    #   sudo: true
+    #   jdk: oraclejdk7
     - os: osx
       osx_image: xcode7.2
     - os: osx

--- a/src/main/groovy/wooga/gradle/paket/base/tasks/AbstractPaketTask.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/AbstractPaketTask.groovy
@@ -55,7 +55,15 @@ abstract class AbstractPaketTask<T extends AbstractPaketTask> extends Convention
     def stdErr = new ByteArrayOutputStream()
 
     @Internal
-    PaketPluginExtension paketExtension
+    private PaketPluginExtension paketExtension
+
+    PaketPluginExtension getPaketExtension() {
+        return paketExtension
+    }
+
+    void setPaketExtension(PaketPluginExtension value) {
+        paketExtension = value
+    }
 
     AbstractPaketTask(Class<T> taskType) {
         super()
@@ -92,7 +100,7 @@ abstract class AbstractPaketTask<T extends AbstractPaketTask> extends Convention
 
     String getExecutable() {
         if (executable == null) {
-            executable = paketExtension.paketExecuteablePath
+            executable = getPaketExtension().paketExecuteablePath
         }
 
         if (executable == null) {
@@ -128,7 +136,7 @@ abstract class AbstractPaketTask<T extends AbstractPaketTask> extends Convention
 
         if (!osName.contains("windows")) {
             logger.info("Use mono: {}.", true)
-            paketArgs << paketExtension.monoExecutable
+            paketArgs << getPaketExtension().monoExecutable
         }
 
         paketArgs << project.file(getExecutable())

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPublishingArtifact.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPublishingArtifact.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.pack
+
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.internal.tasks.DefaultTaskDependency
+import org.gradle.api.internal.tasks.TaskResolver
+import org.gradle.api.tasks.TaskDependency
+import wooga.gradle.paket.pack.tasks.PaketPack
+
+class PaketPublishingArtifact implements PublishArtifact {
+
+    @Override
+    String getName() {
+        return task.packageId
+    }
+
+    @Override
+    String getExtension() {
+        return ".nupkg"
+    }
+
+    @Override
+    String getType() {
+        return "zip"
+    }
+
+    @Override
+    String getClassifier() {
+        return null
+    }
+
+    @Override
+    File getFile() {
+        return this.task.getOutputFile()
+    }
+
+    @Override
+    Date getDate() {
+        return null
+    }
+
+    def taskDependency
+
+    @Override
+    TaskDependency getBuildDependencies() {
+        taskDependency
+    }
+
+    private PaketPack task
+
+    static PublishArtifact fromTask(PaketPack task) {
+        new PaketPublishingArtifact(task)
+    }
+
+    PaketPublishingArtifact(PaketPack task) {
+        this.task = task
+        taskDependency = new DefaultTaskDependency(task.project.tasks as TaskResolver)
+        taskDependency.add(task)
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
@@ -26,6 +26,9 @@ class PaketPack extends AbstractPaketTask {
 
     static String COMMAND = "pack"
 
+    @Internal
+    def packageId
+
     @Optional
     @Input
     def version
@@ -57,7 +60,7 @@ class PaketPack extends AbstractPaketTask {
     File getOutputFile() {
         def templateReader = new PaketTemplateReader(getTemplateFile())
         def packageID = templateReader.getPackageId()
-        project.file({"$outputDir/${packageID}.${version}.nupkg"})
+        project.file({"$outputDir/${packageID}.${getVersion()}.nupkg"})
     }
 
     PaketPack() {

--- a/travis/setup_linux.sh
+++ b/travis/setup_linux.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-echo "deb http://download.mono-project.com/repo/ubuntu precise main" | sudo tee /etc/apt/sources.list.d/mono-official.list
+echo "deb http://download.mono-project.com/repo/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/mono-official.list
 sudo apt-get -qq update
 sudo apt-get install -qq -y mono-xsp4


### PR DESCRIPTION
The project version had to be set before the plugin gets applied.
This commit will bind the version property lazy. The version gets
evaluated at execution time.