### PR TITLE
Enhance/default version in template

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/pack/PaketPackIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/pack/PaketPackIntegrationSpec.groovy
@@ -123,6 +123,181 @@ class PaketPackIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         taskToRun << ["paketPack-WoogaTest", "buildNupkg", "assemble"]
     }
 
+    @Unroll
+    def "use version in template by default #taskToRun"(String taskToRun) {
+        given: "a build file with version set"
+        buildFile.text = ""
+        buildFile << """
+            group = 'test'
+            ${applyPlugin(PaketPackPlugin)}
+            version = "0.0.0"
+        """.stripIndent()
+
+        and: "a custom template file with version"
+        paketTemplateFile.text = ""
+        paketTemplateFile << """
+            type file
+            id $packageID
+            version $version
+            authors Wooga
+            owners Wooga
+            description
+                Empty nuget package.
+        """.stripIndent()
+
+        and: "a future output file"
+        def outputFile = new File(new File(new File(projectDir, 'build'), "outputs"), "${packageID}.${version}.nupkg")
+        def undesiredFile1 = new File(new File(new File(projectDir, 'build'), "outputs"), "${packageID}.0.0.0.nupkg")
+        assert !outputFile.exists()
+
+        and: "a empty paket.dependencies file"
+        createFile("paket.dependencies")
+
+        when:
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        outputFile.exists()
+        !undesiredFile1.exists()
+        result.wasExecuted("paketPack-WoogaTest")
+
+        where:
+        taskToRun << ["paketPack-WoogaTest", "buildNupkg", "assemble"]
+    }
+
+    @Unroll
+    def "falls back to project version #taskToRun"(String taskToRun) {
+        given: "a build file with version set"
+        buildFile.text = ""
+        buildFile << """
+            group = 'test'
+            ${applyPlugin(PaketPackPlugin)}
+            version = "$version"
+        """.stripIndent()
+
+        and: "a custom template file without version"
+        paketTemplateFile.text = ""
+        paketTemplateFile << """
+            type file
+            id $packageID
+            authors Wooga
+            owners Wooga
+            description
+                Empty nuget package.
+        """.stripIndent()
+
+        and: "a future output file"
+        def outputFile = new File(new File(new File(projectDir, 'build'), "outputs"), "${packageID}.${version}.nupkg")
+        assert !outputFile.exists()
+
+        and: "a empty paket.dependencies file"
+        createFile("paket.dependencies")
+
+        when:
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        outputFile.exists()
+        result.wasExecuted("paketPack-WoogaTest")
+
+        where:
+        taskToRun << ["paketPack-WoogaTest", "buildNupkg", "assemble"]
+    }
+
+    @Unroll
+    def "fails #taskToRun when no version is set"(String taskToRun) {
+        given: "a build file without version"
+        buildFile.text = ""
+        buildFile << """
+            group = 'test'
+            ${applyPlugin(PaketPackPlugin)}
+        """.stripIndent()
+
+        and: "a custom template file without version"
+        paketTemplateFile.text = ""
+        paketTemplateFile << """
+            type file
+            id $packageID
+            authors Wooga
+            owners Wooga
+            description
+                Empty nuget package.
+        """.stripIndent()
+
+        and: "a future output file"
+        def outputFile = new File(new File(new File(projectDir, 'build'), "outputs"), "${packageID}.${version}.nupkg")
+        assert !outputFile.exists()
+
+        and: "a empty paket.dependencies file"
+        createFile("paket.dependencies")
+
+        when:
+        def result = runTasksWithFailure(taskToRun)
+
+        then:
+        result.standardError.contains("A problem was found with the configuration of task ':paketPack-WoogaTest'")
+        result.standardError.contains("No value has been specified for property 'version'")
+        !outputFile.exists()
+        result.wasExecuted("paketPack-WoogaTest")
+
+        where:
+        taskToRun << ["paketPack-WoogaTest", "buildNupkg", "assemble"]
+    }
+
+    @Unroll
+    def "use reconfigured task version #taskToRun"() {
+        given: "a build file with version set"
+        buildFile.text = ""
+        buildFile << """
+            group = 'test'
+            ${applyPlugin(PaketPackPlugin)}
+            version = "0.0.0"
+        """.stripIndent()
+
+        and: "a custom template file with version"
+        paketTemplateFile.text = ""
+        paketTemplateFile << """
+            type file
+            id $packageID
+            version 0.1.0
+            authors Wooga
+            owners Wooga
+            description
+                Empty nuget package.
+        """.stripIndent()
+
+        and: "a the paketPack task reconfigured"
+        buildFile << """
+            tasks.getByName("paketPack-WoogaTest") {
+                version = "$version"
+            }
+        """.stripIndent()
+
+        and: "a future output file"
+        def outputFile = new File(new File(new File(projectDir, 'build'), "outputs"), "${packageID}.${version}.nupkg")
+        assert !outputFile.exists()
+
+        and: "undesired output files"
+        def undesiredFile1 = new File(new File(new File(projectDir, 'build'), "outputs"), "${packageID}.0.0.0.nupkg")
+        def undesiredFile2 = new File(new File(new File(projectDir, 'build'), "outputs"), "${packageID}.0.1.0.nupkg")
+
+        and: "a empty paket.dependencies file"
+        createFile("paket.dependencies")
+
+        when:
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        outputFile.exists()
+        result.wasExecuted("paketPack-WoogaTest")
+        !undesiredFile1.exists()
+        !undesiredFile2.exists()
+
+        where:
+        taskToRun << ["paketPack-WoogaTest", "buildNupkg", "assemble"]
+    }
+
+
     def "skips pack task creation for duplicate package id"() {
         given: "some paket template files in the file system with same id"
         def subDir1 = new File(projectDir, "sub1")

--- a/src/main/groovy/wooga/gradle/paket/base/utils/PaketTemplate.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/utils/PaketTemplate.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.utils
+
+class PaketTemplate {
+
+    private def content
+
+    PaketTemplate(File templateFile) {
+        this(templateFile.text)
+    }
+
+    PaketTemplate(String templateContent) {
+        content = [:]
+        templateContent.eachLine { line ->
+            def matcher
+            if ((matcher = line =~ /^(\w+)( |\n[ ]{4})(((\n[ ]{4})?.*)+)/)) {
+                content[matcher[0][1]] = matcher[0][3]
+            }
+        }
+    }
+
+    String getPackageId() {
+        content['id']
+    }
+
+    String getVersion() {
+        content['version']
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.TaskContainer
 import wooga.gradle.paket.base.DefaultPaketPluginExtension
 import wooga.gradle.paket.base.PaketBasePlugin
 import wooga.gradle.paket.base.PaketPluginExtension
+import wooga.gradle.paket.base.utils.PaketTemplate
 import wooga.gradle.paket.get.PaketGetPlugin
 import wooga.gradle.paket.pack.tasks.PaketPack
 
@@ -75,7 +76,7 @@ class PaketPackPlugin implements Plugin<Project> {
         })
 
         templateFiles.each { File file ->
-            def templateReader = new PaketTemplateReader(file)
+            def templateReader = new PaketTemplate(file)
             def packageID = templateReader.getPackageId()
             def packageName = packageID.replaceAll(/\./, '')
             def taskName = TASK_PACK_PREFIX + packageName
@@ -109,6 +110,8 @@ class PaketPackPlugin implements Plugin<Project> {
         tasks.withType(PaketPack, new Action<PaketPack>() {
             @Override
             void execute(PaketPack task) {
+                def templateReader = new PaketTemplate(task.templateFile)
+
                 ConventionMapping taskConventionMapping = task.getConventionMapping()
 
                 taskConventionMapping.map("templateFile", { extention.getBaseUrl() })
@@ -126,24 +129,4 @@ class PaketPackPlugin implements Plugin<Project> {
             }
         }
     }
-
-    private class PaketTemplateReader {
-
-        private def content
-
-        PaketTemplateReader(File templateFile) {
-            content = [:]
-            templateFile.eachLine { line ->
-                def matcher
-                if ((matcher = line =~ /^(\w+)( |\n[ ]{4})(((\n[ ]{4})?.*)+)/)) {
-                    content[matcher[0][1]] = matcher[0][3]
-                }
-            }
-        }
-
-        String getPackageId() {
-            content['id']
-        }
-    }
-
 }

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.util.GUtil
 import wooga.gradle.paket.base.DefaultPaketPluginExtension
 import wooga.gradle.paket.base.PaketBasePlugin
 import wooga.gradle.paket.base.PaketPluginExtension
@@ -62,14 +63,11 @@ class PaketPackPlugin implements Plugin<Project> {
             @Override
             int compare(File o1, File o2) {
                 String sep = File.separator
-                if(o1.path.count(sep) > o2.path.count(sep)) {
+                if (o1.path.count(sep) > o2.path.count(sep)) {
                     return 1
-                }
-                else if(o1.path.count(sep) < o2.path.count(sep)) {
+                } else if (o1.path.count(sep) < o2.path.count(sep)) {
                     return -1
-                }
-                else
-                {
+                } else {
                     return 0
                 }
             }
@@ -110,13 +108,24 @@ class PaketPackPlugin implements Plugin<Project> {
         tasks.withType(PaketPack, new Action<PaketPack>() {
             @Override
             void execute(PaketPack task) {
-                def templateReader = new PaketTemplate(task.templateFile)
+                def paketTemplate = new PaketTemplate(task.templateFile)
 
                 ConventionMapping taskConventionMapping = task.getConventionMapping()
 
                 taskConventionMapping.map("templateFile", { extention.getBaseUrl() })
                 taskConventionMapping.map("outputDir", { project.file("${project.buildDir}/outputs") })
-                taskConventionMapping.map("version", { project.version })
+
+                taskConventionMapping.map("version", {
+                    if (paketTemplate.version) {
+                        return paketTemplate.version
+                    }
+
+                    if (project.version != Project.DEFAULT_VERSION) {
+                        return project.version
+                    }
+
+                    return null
+                })
                 taskConventionMapping.map("paketExtension", { extention })
             }
         })

--- a/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.paket.pack.tasks
 
 import org.gradle.api.tasks.*
 import wooga.gradle.paket.base.tasks.AbstractPaketTask
+import wooga.gradle.paket.base.utils.PaketTemplate
 
 import java.util.concurrent.Callable
 
@@ -58,7 +59,7 @@ class PaketPack extends AbstractPaketTask {
 
     @OutputFile
     File getOutputFile() {
-        def templateReader = new PaketTemplateReader(getTemplateFile())
+        def templateReader = new PaketTemplate(getTemplateFile())
         def packageID = templateReader.getPackageId()
         project.file({"$outputDir/${packageID}.${getVersion()}.nupkg"})
     }
@@ -79,25 +80,6 @@ class PaketPack extends AbstractPaketTask {
 
         if (getTemplateFile() != null) {
             args << "templatefile" << getTemplateFile()
-        }
-    }
-
-    private class PaketTemplateReader {
-
-        private def content
-
-        PaketTemplateReader(File templateFile) {
-            content = [:]
-            templateFile.eachLine { line ->
-                def matcher
-                if ((matcher = line =~ /^(\w+)( |\n[ ]{4})(((\n[ ]{4})?.*)+)/)) {
-                    content[matcher[0][1]] = matcher[0][3]
-                }
-            }
-        }
-
-        String getPackageId() {
-            content['id']
         }
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.paket.pack.tasks
 
+import org.gradle.api.Project
 import org.gradle.api.tasks.*
 import wooga.gradle.paket.base.tasks.AbstractPaketTask
 import wooga.gradle.paket.base.utils.PaketTemplate
@@ -30,7 +31,6 @@ class PaketPack extends AbstractPaketTask {
     @Internal
     def packageId
 
-    @Optional
     @Input
     def version
 
@@ -72,14 +72,14 @@ class PaketPack extends AbstractPaketTask {
     @Override
     protected void configureArguments() {
         super.configureArguments()
-        args << "output" << getOutputDir()
+        args << "output" << getOutputDir().path
 
-        if (getVersion() != null) {
+        if (getVersion() != Project.DEFAULT_VERSION) {
             args << "version" << getVersion()
         }
 
         if (getTemplateFile() != null) {
-            args << "templatefile" << getTemplateFile()
+            args << "templatefile" << getTemplateFile().path
         }
     }
 }

--- a/src/test/groovy/wooga/gradle/paket/base/utils/PaketTemplateSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/base/utils/PaketTemplateSpec.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.utils
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PaketTemplateSpec extends Specification {
+
+    static String PACKAGE_ID = "Test.Paket.Package"
+    static String PACKAGE_VERSION = "1.0.0"
+
+    static String TEMPLATE_CONTENT = """
+    type file
+    id $PACKAGE_ID
+    version $PACKAGE_VERSION
+    """.stripIndent()
+
+
+    @Shared
+    File templateFile = File.createTempFile("paket", ".template")
+
+    @Unroll
+    def "initialize with #objectType"() {
+        expect:
+        new PaketTemplate(content)
+
+        where:
+        objectType | content
+        "String"   | TEMPLATE_CONTENT
+        "File"     | templateFile << TEMPLATE_CONTENT
+    }
+
+    @Unroll
+    def "parses id from template with #objectType"() {
+        when:
+        def template = new PaketTemplate(content)
+
+        then:
+        template.getPackageId() == PACKAGE_ID
+
+        where:
+        objectType | content
+        "String"   | TEMPLATE_CONTENT
+        "File"     | templateFile << TEMPLATE_CONTENT
+    }
+
+    @Unroll
+    def "parses version from template with #objectType"() {
+        when:
+        def template = new PaketTemplate(content)
+
+        then:
+        template.getVersion() == PACKAGE_VERSION
+
+        where:
+        objectType | content
+        "String"   | TEMPLATE_CONTENT
+        "File"     | templateFile << TEMPLATE_CONTENT
+    }
+
+    @Unroll
+    def "returns null for non existent #property"() {
+        when:
+        def template = new PaketTemplate("")
+
+        then:
+        template.invokeMethod(property, null) == null
+
+        where:
+        property       | _
+        "getVersion"   | _
+        "getPackageId" | _
+    }
+
+}


### PR DESCRIPTION
## Description

To be able to configure the version of the package to pack we need to change version behavior

The default value for the version parameter in the `PaketPack` task will be determined like this:

1. use version in `paket.template` if available
2. fallback to `project.version` if available (`!=unspecified`)

If the default value for version property couldn't be set and the task wasn't configured with a custom version, `gradle` will fail.

## Changes

![IMPROVE] paket pack default version behavior
![IMPROVE] create single `PaketTemplate` utility class


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"

