### PR TITLE
Add publishLocal tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .gradle
 build/
-out/
+.idea
+out
+*.iml
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -14,3 +16,4 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 userHome/
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
 
         stage('Test') {
             steps {
-                gradleWrapper "check"
+                gradleWrapper "check --info"
             }
         }
     }

--- a/src/integrationTest/groovy/wooga/gradle/paket/publish/PaketPublishIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/publish/PaketPublishIntegrationSpec.groovy
@@ -17,7 +17,6 @@
 
 package wooga.gradle.paket.publish
 
-import nebula.test.IntegrationSpec
 import org.jfrog.artifactory.client.Artifactory
 import org.jfrog.artifactory.client.ArtifactoryClient
 import org.jfrog.artifactory.client.model.RepoPath
@@ -36,7 +35,7 @@ class PaketPublishIntegrationSpec extends PaketIntegrationDependencyFileSpec {
     def uniquPackagePostfix() {
         String key = "TRAVIS_JOB_NUMBER"
         def env = System.getenv()
-        if(env.containsKey(key)) {
+        if (env.containsKey(key)) {
             return env.get(key)
         }
         return ""
@@ -64,6 +63,7 @@ class PaketPublishIntegrationSpec extends PaketIntegrationDependencyFileSpec {
 
     def artifactoryRepoName = "atlas-nuget-integrationTest"
     def repoUrl = "$artifactoryUrl/api/nuget/atlas-nuget-integrationTest"
+    def localPath
 
     def packageIdToName(id) {
         id.replaceAll(/\./, '')
@@ -109,14 +109,16 @@ class PaketPublishIntegrationSpec extends PaketIntegrationDependencyFileSpec {
                 Empty nuget package.
         """.stripIndent()
 
-        cleanupArtifactory(artifactoryRepoName,packageName)
+        localPath = File.createTempDir()
+        localPath.deleteOnExit()
+        cleanupArtifactory(artifactoryRepoName, packageName)
     }
 
     def cleanup() {
-        cleanupArtifactory(artifactoryRepoName,packageName)
+        cleanupArtifactory(artifactoryRepoName, packageName)
     }
 
-    def cleanupArtifactory(String repoName,String artifactName) {
+    def cleanupArtifactory(String repoName, String artifactName) {
         List<RepoPath> searchItems = artifactory.searches()
                 .repositories(repoName)
                 .artifactsByName(artifactName)
@@ -129,7 +131,7 @@ class PaketPublishIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         }
     }
 
-    def hasPackageOnArtifactory(String repoName,String artifactName) {
+    def hasPackageOnArtifactory(String repoName, String artifactName) {
         List<RepoPath> packages = artifactory.searches()
                 .repositories(repoName)
                 .artifactsByName(artifactName)
@@ -156,6 +158,56 @@ class PaketPublishIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         nugetArtifact.exists()
         result.wasExecuted("paketPack-${packageIdToName(packageID)}")
         hasPackageOnArtifactory(artifactoryRepoName, packageName)
+
+        where:
+        taskToRun << ["publish-${packageIdToName(packageID)}", "publish${repoName.capitalize()}-${packageIdToName(packageID)}", "publish${repoName.capitalize()}", "publish"]
+    }
+
+    @Unroll
+    def 'builds package and publish locally #taskToRun'(String taskToRun) {
+        given: "the future npkg artifact"
+        def nugetArtifact = new File(new File(new File(projectDir, 'build'), "outputs"), packageName)
+        assert !nugetArtifact.exists()
+
+        and: "paket.dependencies and paket.lock file"
+        createFile("paket.lock")
+        createFile("paket.dependencies")
+
+        and: "a build.gradle file with a local publish entry"
+        buildFile.text = ""
+        buildFile << """
+            group = 'test'
+            version = "$version"
+
+            ${applyPlugin(PaketPackPlugin)}
+            ${applyPlugin(PaketPublishPlugin)}
+
+            publishing {
+                repositories {
+                    nuget {
+                        name "$repoName"
+                        path "$localPath"
+                    }
+                }
+            }
+
+            paketPublish {
+                publishRepositoryName = "$repoName"
+            }
+
+        """.stripIndent()
+
+        and: "a future local output file"
+        def futureFile = new File(localPath, nugetArtifact.name)
+        assert !futureFile.exists()
+
+        when: "run the publish task"
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        nugetArtifact.exists()
+        result.wasExecuted("paketPack-${packageIdToName(packageID)}")
+        futureFile.exists()
 
         where:
         taskToRun << ["publish-${packageIdToName(packageID)}", "publish${repoName.capitalize()}-${packageIdToName(packageID)}", "publish${repoName.capitalize()}", "publish"]

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -121,7 +121,7 @@ class PaketPackPlugin implements Plugin<Project> {
                     }
 
                     if (project.version != Project.DEFAULT_VERSION) {
-                        return project.version
+                        return project.version.toString()
                     }
 
                     return null

--- a/src/main/groovy/wooga/gradle/paket/publish/PaketPublishPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/PaketPublishPlugin.groovy
@@ -89,10 +89,10 @@ class PaketPublishPlugin implements Plugin<Project> {
             }
         }
 
-        registerPublishLocal(tasks)
+        createPublishLocalTask(tasks)
     }
 
-    void registerPublishLocal(TaskContainer tasks) {
+    void createPublishLocalTask(TaskContainer tasks) {
         def paketCopylifecycle = tasks.create(name: "publishLocal", group: PublishingPlugin.PUBLISH_TASK_GROUP, description: "publish all nupkg to all local paths")
         paketCopylifecycle.dependsOn tasks.withType(PaketCopy)
     }

--- a/src/main/groovy/wooga/gradle/paket/publish/repository/NugetRepository.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/repository/NugetRepository.groovy
@@ -22,16 +22,35 @@ class NugetRepository implements NugetArtifactRepository {
     String apiKey
     String url
     String name
+    String path
 
     def name(String name) {
         setName(name)
     }
 
     def url(String url) {
+        if(path != null)
+        {
+            throw new Exception("path already set")
+        }
         setUrl(url)
     }
 
     def apiKey(String apiKey) {
         setApiKey(apiKey)
     }
+
+    def path(String path){
+        if(url != null)
+        {
+            throw new Exception("url already set")
+        }
+        setPath(path)
+    }
+
+    def getDestination(){
+        path ? path : url
+    }
+
+
 }

--- a/src/main/groovy/wooga/gradle/paket/publish/tasks/PaketCopy.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/tasks/PaketCopy.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.publish.tasks
+
+import org.gradle.api.tasks.Copy
+
+class PaketCopy extends Copy {
+}

--- a/src/test/groovy/wooga/gradle/paket/pack/PaketPackPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/pack/PaketPackPluginSpec.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.paket.pack
 import nebula.test.PluginProjectSpec
 import nebula.test.ProjectSpec
 import org.gradle.api.plugins.BasePlugin
+import spock.lang.Specification
 import spock.lang.Unroll
 import wooga.gradle.paket.base.PaketBasePlugin
 import wooga.gradle.paket.get.PaketGetPlugin

--- a/src/test/groovy/wooga/gradle/paket/publish/repository/NugetRepositorySpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/publish/repository/NugetRepositorySpec.groovy
@@ -1,0 +1,35 @@
+package wooga.gradle.paket.publish.repository
+
+import spock.lang.Specification
+
+class NugetRepositorySpec extends Specification {
+
+    def "applies properties"(){
+
+        given: "a fresh NugetRepository object"
+        def vo = new NugetRepository()
+
+        when: "set properties via methods"
+        vo.url("url")
+        vo.name("name")
+        vo.apiKey("apiKey")
+
+        then:
+        vo.url == "url"
+        vo.name == "name"
+        vo.apiKey == "apiKey"
+    }
+
+    def "applies all properties"(){
+
+        given: "a fresh NugetRepository object"
+        def vo = new NugetRepository()
+
+        when: "set path and url"
+        vo.url("url")
+        vo.path("path")
+
+        then: "Exception gets thrown"
+        thrown(Exception)
+    }
+}


### PR DESCRIPTION
## Description
Add a set of tasks to publish `nupkg` package to a local destination. This helps when developing new features and you want to test them in other projects (PuzzleCore use case).

**How to set it up:**

```

publishing {
    repositories {
        nuget {
            name "snapshot"
            url "https://wooga.jfrog.io/wooga/api/nuget/atlas-nuget-snapshot"
        }

        nuget {
            name "rc"
            url "https://wooga.jfrog.io/wooga/api/nuget/atlas-nuget-rc"
        }

        nuget {
            name "final"
            url "https://wooga.jfrog.io/wooga/api/nuget/atlas-nuget-release"
        }

        nuget {
            name "localExportOne"
            path "../myOtherProject"
        }

        nuget {
            name "localExportTwo"
            path "../myLocalNugetStorage"
        }
    }
}
```
You have to set a `path` instead of `url` 

This generates a new set of tasks:

```
publishLocal - publish all nupkg to all local paths
publishLocallocalExportOne - Publishes all nupkg artifacts to ../myOtherProject
publishLocallocalExportTwo - Publishes all nupkg artifacts to ../myLocalNugetStorage
publishLocallocalExportOne-Wooga.MyPackageId  - Copies Wooga.MyPackageId.0.1.0-dev.3.uncommitted+5ae8199.nupkg to../myOtherProject
publishLocallocalExportTwo-Wooga.MyPackageId  - Copies Wooga.MyPackageId.0.1.0-dev.3.uncommitted+5ae8199.nupkg to../myLocalNugetStorage
```