### PR TITLE
Attach paketUnityInstall task to all relevant tasks

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
@@ -183,7 +183,7 @@ class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         nuget $nuget2 $updateConstraint2
         """.stripIndent()
 
-        def result = runTasksSuccessfully("paketUpdate$nuget1")
+        runTasksSuccessfully("paketUpdate$nuget1")
 
         then:
         !lockFile.text.contains("$nuget1 ($version1)")

--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
@@ -17,9 +17,9 @@
 
 package wooga.gradle.paket.get
 
-import spock.lang.Ignore
 import spock.lang.Unroll
 import wooga.gradle.paket.PaketIntegrationDependencyFileSpec
+import wooga.gradle.paket.unity.PaketUnityPlugin
 
 class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
 
@@ -183,11 +183,10 @@ class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         nuget $nuget2 $updateConstraint2
         """.stripIndent()
 
-        runTasksSuccessfully("paketUpdate$nuget1")
+        def result = runTasksSuccessfully("paketUpdate$nuget1")
 
         then:
         !lockFile.text.contains("$nuget1 ($version1)")
         lockFile.text.contains("$nuget2 ($version2)")
-
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -17,13 +17,13 @@
 
 package wooga.gradle.paket.unity
 
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.tasks.TaskContainer
 import wooga.gradle.paket.base.PaketBasePlugin
-import wooga.gradle.paket.base.tasks.AbstractPaketTask
 import wooga.gradle.paket.get.PaketGetPlugin
+import wooga.gradle.paket.get.tasks.PaketUpdate
 import wooga.gradle.paket.unity.tasks.PaketUnityBootstrap
 import wooga.gradle.paket.unity.tasks.PaketUnityInstall
 
@@ -71,13 +71,18 @@ class PaketUnityPlugin implements Plugin<Project> {
 
     void configurePaketDependencyInstallIfPresent() {
         project.plugins.withType(PaketGetPlugin) {
+
+            def paketUnityInstall = tasks[INSTALL_TASK_NAME]
             def paketInstall = project.tasks[PaketGetPlugin.INSTALL_TASK_NAME]
-            def paketUpdate = project.tasks[PaketGetPlugin.UPDATE_TASK_NAME]
             def paketRestore = project.tasks[PaketGetPlugin.RESTORE_TASK_NAME]
 
-            [paketInstall, paketUpdate, paketRestore].each { Task task ->
-                task.finalizedBy tasks[PaketUnityPlugin.INSTALL_TASK_NAME]
+            Closure configClosure = { task ->
+                task.finalizedBy paketUnityInstall
             }
+
+            project.tasks.withType(PaketUpdate, configClosure)
+
+            [paketInstall, paketRestore].each configClosure
         }
     }
 }


### PR DESCRIPTION
we discovered a bug where `paketUnityInstall`doesn't get called after `paketUpdateMyDependencyName`. 

This fix ensures `paketUnityInstall` to be called after every call to `paketUpdateMyDependencyName`

Fixes #12 