### PR TITLE
Move getLockfile getter to PaketPluginExtension

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/base/PaketPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/PaketPluginExtension.groovy
@@ -183,6 +183,13 @@ interface PaketPluginExtension {
     File getPaketDependenciesFile()
 
     /**
+     * Returns the {@link File} path to the {@code paket.lock} file in the project.
+     *
+     * @return a {@link File} path to the {@code paket.lock} file in the project.
+     */
+    File getPaketLockFile()
+
+    /**
      * Returns the content of {@code paket.dependencies} parsed as {@link PaketDependencies} object.
      *
      * @return  the parsed {@code paket.dependencies} file

--- a/src/main/groovy/wooga/gradle/paket/base/internal/DefaultPaketPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/internal/DefaultPaketPluginExtension.groovy
@@ -32,6 +32,7 @@ class DefaultPaketPluginExtension implements PaketPluginExtension {
 
     private static final String DEFAULT_VERSION = ""
     private static final String DEFAULT_MONO_EXECUTABLE = "mono"
+    private static final String DEFAULT_PAKET_LOCK_FILE_NAME = "paket.lock"
 
     protected Project project
     protected File customPaketDirectory
@@ -166,5 +167,10 @@ class DefaultPaketPluginExtension implements PaketPluginExtension {
 
     protected String getBootstrapperExecutableName() {
         DEFAULT_PAKET_BOOTSTRAPPER_EXECUTION_NAME
+    }
+
+    @Override
+    File getPaketLockFile() {
+        return new File(project.projectDir, DEFAULT_PAKET_LOCK_FILE_NAME)
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
@@ -25,9 +25,4 @@ interface PaketUnityPluginExtension extends PaketPluginExtension {
      * @param directory name of the output directory
      */
     void setPaketOutputDirectoryName(String directory)
-
-    /**
-     * @return a {@link File} path to the {@code paket.lock} file in the project.
-     */
-    File getPaketLockFile()
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -26,7 +26,6 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
     public static final String DEFAULT_PAKET_UNITY_REFERENCES_FILE_NAME = "paket.unity3d.references"
     public static final String DEFAULT_PAKET_DIRECTORY = "Paket.Unity3D"
-    private static final String DEFAULT_PAKET_LOCK_FILE_NAME = "paket.lock"
 
     protected String customPaketOutputDirectory
 
@@ -47,10 +46,5 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
     void setPaketOutputDirectoryName(String directory) {
         customPaketOutputDirectory = directory
-    }
-
-    @Override
-    File getPaketLockFile() {
-        return new File(project.projectDir, DEFAULT_PAKET_LOCK_FILE_NAME)
     }
 }


### PR DESCRIPTION
## Description

Just a small refactor to keep the API clean. The paketUnity extension
implemented a new getter `getLockFile`. It makes more sense to move this
property to the base class/interface `PaketPluginExtension`.

## Changes

![IMPROVE] move `getLockFile` property to `PaketPluginExtension`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
