### PR TITLE
Add endpoint input value to PaketPush

### DIFF
--- a/docs/Publish.md
+++ b/docs/Publish.md
@@ -33,6 +33,7 @@ publishing {
             name "internal name of the repository"
             url "url to repository"
             apiKey = "optional api key"
+            endpoint = "optional endpoint" //default /api/v2/package
         }
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/publish/PaketPublishPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/PaketPublishPlugin.groovy
@@ -142,6 +142,7 @@ class PaketPublishPlugin implements Plugin<Project> {
         PaketPush task = (PaketPush) tasks.create(name: publishTaskName, group: PublishingPlugin.PUBLISH_TASK_GROUP, type: PaketPush)
         task.url = repository.url
         task.apiKey = repository.apiKey
+        task.endpoint = repository.endpoint
         task.inputFile = artifact.file
         task.description = "Publishes ${artifact.file.name} to ${repository.url}"
         task

--- a/src/main/groovy/wooga/gradle/paket/publish/repository/NugetArtifactRepository.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/repository/NugetArtifactRepository.groovy
@@ -26,4 +26,7 @@ interface NugetArtifactRepository extends ArtifactRepository {
 
     String getUrl()
     void setUrl(String url)
+
+    String getEndpoint()
+    void setEndpoint(String endpoint)
 }

--- a/src/main/groovy/wooga/gradle/paket/publish/repository/internal/NugetRepository.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/repository/internal/NugetRepository.groovy
@@ -23,6 +23,7 @@ class NugetRepository implements NugetArtifactRepository {
 
     String apiKey
     String url
+    String endpoint
     String name
     String path
 
@@ -40,6 +41,10 @@ class NugetRepository implements NugetArtifactRepository {
 
     def apiKey(String apiKey) {
         setApiKey(apiKey)
+    }
+
+    def endpoint(String endpoint) {
+        setEndpoint(endpoint)
     }
 
     def path(String path){

--- a/src/main/groovy/wooga/gradle/paket/publish/tasks/PaketPush.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/tasks/PaketPush.groovy
@@ -96,6 +96,22 @@ class PaketPush extends AbstractPaketTask {
         project.file inputFile
     }
 
+    def endpoint
+
+    @Optional
+    @Input
+    String getEndpoint() {
+        if( endpoint == null)
+        {
+            null
+        }
+        else if (endpoint instanceof Callable) {
+            endpoint.call()
+        } else {
+            endpoint.toString()
+        }
+    }
+
     PaketPush() {
         super(PaketPush.class)
         description = "Pushes the given .nupkg file."
@@ -111,6 +127,11 @@ class PaketPush extends AbstractPaketTask {
         if(getApiKey() != null)
         {
             args << "apikey" << getApiKey()
+        }
+
+        if(getEndpoint() != null)
+        {
+            args << "endpoint" << getEndpoint()
         }
 
         args << "file" << getinputFile().path

--- a/src/test/groovy/wooga/gradle/paket/publish/repository/NugetRepositorySpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/publish/repository/NugetRepositorySpec.groovy
@@ -14,11 +14,13 @@ class NugetRepositorySpec extends Specification {
         vo.url("url")
         vo.name("name")
         vo.apiKey("apiKey")
+        vo.endpoint("endpoint")
 
         then:
         vo.url == "url"
         vo.name == "name"
         vo.apiKey == "apiKey"
+        vo.endpoint == "endpoint"
     }
 
     def "applies all properties"(){


### PR DESCRIPTION
Description
===========

Paket push supports a custom `--endpoint` or `endpoint` flag for the
`push command. This pull requests adds support for this option.
The task `PaketPush` contains a new property endpoint which
when sets adds this argument to the `paket push` command.

The Nuget Repository object also contains a new setter for `endpoint`
this allows to configure the endpoint at publish repository level.

```groovy
publishing {
    repositories {
        nuget {
            name "nuget1"
            url "https://nuget.feed"
            endpoint "/api/v2/package"
        }
    }
}
```
resolves #24 

Changes
=======

![ADD] `endpoint` property to `PaketPush`
![ADD] `endpoint` property to `NugetRepository`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
