### PR TITLE
Refactor PaketPack task properties

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -107,9 +107,8 @@ class PaketPackPlugin implements Plugin<Project> {
 
             packTask = tasks.create(taskName, PaketPack.class)
             packTask.group = BasePlugin.BUILD_GROUP
-            packTask.description = "Pack package ${templateReader.getPackageId()}"
+            packTask.description = "Pack package ${packageID}"
             packTask.templateFile = file
-            packTask.packageId = packageID
 
             PublishArtifact artifact = PaketPublishingArtifact.fromTask(packTask)
 

--- a/src/main/groovy/wooga/gradle/paket/pack/internal/PaketPublishingArtifact.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/internal/PaketPublishingArtifact.groovy
@@ -27,7 +27,7 @@ class PaketPublishingArtifact implements PublishArtifact {
 
     @Override
     String getName() {
-        return task.packageId
+        return task.getPackageId()
     }
 
     @Override

--- a/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
@@ -39,15 +39,18 @@ import wooga.gradle.paket.base.utils.internal.PaketTemplate
  */
 class PaketPack extends AbstractPaketTask {
 
-    @Internal
-    def packageId
+    /**
+     * @return the packageId of the nuget to be packed.
+     */
+    String getPackageId() {
+        new PaketTemplate(getTemplateFile()).getPackageId()
+    }
 
     /**
      * The nuget package version.
      */
     @Input
     String version
-
 
     @Optional
     @InputFile
@@ -73,9 +76,7 @@ class PaketPack extends AbstractPaketTask {
      */
     @OutputFile
     File getOutputFile() {
-        def templateReader = new PaketTemplate(getTemplateFile())
-        def packageID = templateReader.getPackageId()
-        project.file({"$outputDir/${packageID}.${getVersion()}.nupkg"})
+        project.file({"$outputDir/${getPackageId()}.${getVersion()}.nupkg"})
     }
 
     PaketPack() {


### PR DESCRIPTION
Description
===========

The internal usage of `packageID` property was confusing. This pr
changes the handling of `packageID` provided by `paket.template`

resolves #23 

Changes
=======

![IMPROVE] `PaketPack` properties

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
