### PR TITLE
Expose args property from AbstractPaketTask to all tasks

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationArgumentsSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationArgumentsSpec.groovy
@@ -1,0 +1,109 @@
+package wooga.gradle.paket
+
+import nebula.test.IntegrationSpec
+import spock.lang.IgnoreIf
+import spock.lang.Unroll
+
+abstract class PaketIntegrationArgumentsSpec extends IntegrationSpec {
+
+    abstract Class getTestPlugin()
+    abstract List<String> getTestTasks()
+
+    def setup() {
+        given: "a paket dependency file"
+        createFile("paket.dependencies")
+
+        and: "a empty lock file"
+        createFile("paket.lock")
+
+        buildFile << """
+            group = 'test'
+            ${applyPlugin(getTestPlugin())}
+        """.stripIndent()
+    }
+
+    @IgnoreIf({ env["CI"] })
+    @Unroll
+    def "task: #taskToRun is available"() {
+        when:
+        def result = runTasksSuccessfully("tasks")
+
+        then:
+        result.standardOutput.contains(taskToRun)
+
+        where:
+        taskToRun << getTestTasks()
+    }
+
+    @Unroll
+    def "task :#taskToRun can set custom arguments '-customFlag1, -customFlag2' with args(arguments,...)"() {
+        given:
+        buildFile << """
+
+        project.tasks."${taskToRun}" {
+            args($value)
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasks(taskToRun)
+
+        then:
+        result.wasExecuted(taskToRun)
+        result.standardOutput.contains("Starting process 'command '")
+        result.standardOutput.contains(" $expectedCommandlineSwitch")
+
+        where:
+        taskToRun << getTestTasks()
+        value = '"-customFlag1", "-customFlag2"'
+        expectedCommandlineSwitch = '-customFlag1 -customFlag2'
+    }
+
+    @Unroll
+    def "task :#taskToRun can set custom arguments '-customFlag1, -customFlag2' with args([arguments])"() {
+        given:
+        buildFile << """
+        
+        project.tasks."${taskToRun}" {
+            args($value) 
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasks(taskToRun)
+
+        then:
+        result.wasExecuted(taskToRun)
+        result.standardOutput.contains("Starting process 'command '")
+        result.standardOutput.contains(" $expectedCommandlineSwitch")
+
+        where:
+        taskToRun << getTestTasks()
+        value = '["-customFlag1", "-customFlag2"]'
+        expectedCommandlineSwitch = '-customFlag1 -customFlag2'
+    }
+
+    @Unroll
+    def "task :#taskToRun can set custom arguments '-customFlag1, -customFlag2' with args = [arguments]"() {
+        given:
+        buildFile << """
+        
+        project.tasks."${taskToRun}" {
+            args = $value 
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasks(taskToRun)
+
+        then:
+        result.wasExecuted(taskToRun)
+        result.standardOutput.contains("Starting process 'command '")
+        result.standardOutput.contains(" $expectedCommandlineSwitch")
+
+        where:
+        taskToRun << getTestTasks()
+        value = '["-customFlag1", "-customFlag2"]'
+        expectedCommandlineSwitch = '-customFlag1 -customFlag2'
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
@@ -21,6 +21,7 @@ import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import spock.lang.Shared
 import spock.lang.Unroll
+import wooga.gradle.paket.get.PaketGetPlugin
 
 abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
 

--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketGetArgumentsSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketGetArgumentsSpec.groovy
@@ -1,0 +1,24 @@
+package wooga.gradle.paket.get;
+
+import wooga.gradle.paket.PaketIntegrationArgumentsSpec;
+import wooga.gradle.paket.PaketPlugin;
+
+import java.util.List;
+
+class PaketGetArgumentsSpec extends PaketIntegrationArgumentsSpec {
+
+    @Override
+    Class getTestPlugin() {
+        return PaketGetPlugin.class
+    }
+
+    @Override
+    List<String> getTestTasks() {
+        return [
+                PaketGetPlugin.INSTALL_TASK_NAME,
+                PaketGetPlugin.UPDATE_TASK_NAME,
+                PaketGetPlugin.RESTORE_TASK_NAME,
+                PaketGetPlugin.OUTDATED_TASK_NAME
+        ]
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/paket/pack/PaketPackArgumentsSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/pack/PaketPackArgumentsSpec.groovy
@@ -1,0 +1,38 @@
+package wooga.gradle.paket.pack
+
+import wooga.gradle.paket.PaketIntegrationArgumentsSpec
+
+class PaketPackArgumentsSpec extends PaketIntegrationArgumentsSpec {
+
+    @Override
+    Class getTestPlugin() {
+        return PaketPackPlugin.class
+    }
+
+    @Override
+    List<String> getTestTasks() {
+        return ["paketPack-WoogaTest"]
+    }
+
+    def paketTemplateFile
+    def version = "1.0.0"
+    def packageID = "Wooga.Test"
+
+    def setup() {
+        buildFile << """
+            version = "$version"
+        """.stripIndent()
+
+        paketTemplateFile = createFile("paket.template")
+        paketTemplateFile << """
+            type file
+            id $packageID
+            authors Wooga
+            owners Wooga
+            description
+                Empty nuget package.
+        """.stripIndent()
+
+        createFile("paket.lock")
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/tasks/internal/AbstractPaketTask.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/internal/AbstractPaketTask.groovy
@@ -64,7 +64,53 @@ abstract class AbstractPaketTask<T extends AbstractPaketTask> extends Convention
     @Internal
     protected ByteArrayOutputStream stdErr
 
-    protected Collection<String> args = []
+    protected ArrayList<String> arguments = []
+
+    /**
+     * Returns the arguments for the command to be executed. Defaults to an empty list.
+     */
+    List<String> getArgs() {
+        arguments
+    }
+
+    /**
+     * Adds arguments for the command to be executed.
+     *
+     * @param args args for the command
+     * @return this
+     */
+    T args(Object... args) {
+        args.each {
+            arguments.add(it.toString())
+        }
+
+        T.cast(this)
+    }
+
+    /**
+     * Adds arguments for the command to be executed.
+     *
+     * @param args args for the command
+     * @return this
+     */
+    T args(Iterable<?> args) {
+        args.each {
+            arguments.add(it.toString())
+        }
+
+        T.cast(this)
+    }
+
+    /**
+     * Sets the arguments for the command to be executed.
+     *
+     * @param args args for the command
+     * @return this
+     */
+    T setArgs(Iterable<?> args) {
+        arguments.clear()
+        this.args(args)
+    }
 
     AbstractPaketTask(Class<T> taskType) {
         super()


### PR DESCRIPTION
## Description

This pull request adds changes to allow all possible additional paket
command switches be set through the gradle tasks. The most important
switches are implemented already within the task interface. But some
optional switches are not. We don't want to add a big support list of
all possible commandline options at the time, the users of the tasks can
configure these options themself.

## Changes

![IMPROVE] paket tasks interface

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
