### PR TITLE
Fix set of lazy version parameter for paketPack

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.tasks.*
 import wooga.gradle.paket.internal.PaketCommand
 import wooga.gradle.paket.base.tasks.internal.AbstractPaketTask
 import wooga.gradle.paket.base.utils.internal.PaketTemplate
+import java.util.concurrent.Callable
 
 /**
  * A task to invoke {@code paket pack} command with given {@code paket.template} file.
@@ -50,7 +51,23 @@ class PaketPack extends AbstractPaketTask {
      * The nuget package version.
      */
     @Input
-    String version
+    String getVersion() {
+        if (!version) {
+            return null
+        }
+
+        if (version instanceof Callable) {
+            version = version.call()
+        }
+
+        version.toString()
+    }
+
+    private Object version
+
+    void setVersion(Object value) {
+        this.version = value
+    }
 
     @Optional
     @InputFile


### PR DESCRIPTION
## Description

This change makes it possible to set the `version` parameter in the task `PaketPack` as a lazy value (`Closure`, eg `Callable`).

## Changes

* ![FIX] version parameter in `PaketPack`

resolves #31 

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
