### PR TITLE
Update list of supported gradle versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,23 @@ Gradle and Java Compatibility
 Built with Oracle JDK7
 Tested with Oracle JDK8
 
-| Gradle Version | Works |
-| :------------: | :---: |
-| 3.4.1          | yes   |
-| 3.5            | yes   |
+| Gradle Version | Works  |
+| :------------: | :----: |
+| < 3.0          | ![no]  |
+| 3.0            | ![yes] |
+| 3.1            | ![yes] |
+| 3.2            | ![yes] |
+| 3.3            | ![yes] |
+| 3.4            | ![yes] |
+| 3.5            | ![yes] |
+| 3.5.1          | ![yes] |
+| 4.0            | ![yes] |
+| 4.1            | ![yes] |
+| 4.2            | ![yes] |
+| 4.3            | ![yes] |
+| 4.4            | ![yes] |
+| 4.5            | ![yes] |
+| 4.6            | ![yes] |
 
 Development
 ===========
@@ -92,3 +105,6 @@ limitations under the License.
 [gradle]:               https://gradle.org/ "Gradle"
 [gradle_finalizedBy]:   https://docs.gradle.org/3.5/dsl/org.gradle.api.Task.html#org.gradle.api.Task:finalizedBy
 [gradle_dependsOn]:     https://docs.gradle.org/3.5/dsl/org.gradle.api.Task.html#org.gradle.api.Task:dependsOn
+
+[yes]:              https://atlas-resources.wooga.com/icons/icon_check.svg "yes"
+[no]:               https://atlas-resources.wooga.com/icons/icon_uncheck.svg "no"

--- a/gradle_check_versions.sh
+++ b/gradle_check_versions.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+versions=("3.0" "3.1" "3.2" "3.4" "3.4.1" "3.5" "3.5.1" "4.0" "4.1" "4.2" "4.3" "4.4" "4.5" "4.6")
+for i in "${versions[@]}"
+do
+    echo "test gradle version $i"
+    GRADLE_VERSION=$i ./gradlew integrationTest &> /dev/null
+    status=$?
+    mkdir -p "build/reports/$i"
+    mv build/reports/integrationTest "build/reports/$i"
+    if [ $status -ne 0 ]; then
+        echo "test error $i"
+    fi
+done

--- a/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket
+
+class IntegrationSpec extends nebula.test.IntegrationSpec{
+
+    def setup() {
+        def gradleVersion = System.getenv("GRADLE_VERSION")
+        if (gradleVersion) {
+            this.gradleVersion = gradleVersion
+            fork = true
+        }
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationArgumentsSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationArgumentsSpec.groovy
@@ -1,6 +1,5 @@
 package wooga.gradle.paket
 
-import nebula.test.IntegrationSpec
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 

--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
@@ -17,11 +17,9 @@
 
 package wooga.gradle.paket
 
-import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import spock.lang.Shared
 import spock.lang.Unroll
-import wooga.gradle.paket.get.PaketGetPlugin
 
 abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
 
@@ -93,7 +91,7 @@ abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
     }
 
     boolean hasNoSource(ExecutionResult result, String taskName) {
-        containsOutput(result.standardOutput, taskName, "NO-SOURCE")
+        containsOutput(result.standardOutput, taskName, "NO-SOURCE") || result.standardOutput.contains("Skipping task ':$taskName'")
     }
 
     private boolean containsOutput(String stdout, String taskName, String stateIdentifier) {

--- a/src/main/groovy/wooga/gradle/paket/base/internal/DefaultPaketPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/internal/DefaultPaketPluginExtension.groovy
@@ -28,7 +28,7 @@ class DefaultPaketPluginExtension implements PaketPluginExtension {
     private static final String DEFAULT_PAKET_BOOTSTRAPPER_EXECUTION_NAME = "paket.bootstrapper.exe"
     private static final String DEFAULT_PAKET_DEPENDENCIES_FILE_NAME = "paket.dependencies"
     private static
-    final String DEFAULT_PAKET_BOOTSTRAPPER_URL = "https://github.com/fsprojects/Paket/releases/download/4.8.5/paket.bootstrapper.exe"
+    final String DEFAULT_PAKET_BOOTSTRAPPER_URL = "https://github.com/fsprojects/Paket/releases/download/5.155.0/paket.bootstrapper.exe"
 
     private static final String DEFAULT_VERSION = ""
     private static final String DEFAULT_MONO_EXECUTABLE = "mono"


### PR DESCRIPTION
## Description

This pull requests adds a simple test script to check with the help of
integration tests which Gradle version works. I also did some changes in
the test setup to make these tests possible.

## Changes

![UPDATE] supported gradle versions list

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
