### PR TITLE
Update paket restore UP-TO-DATE handling and clean pattern

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/base/PaketBaseIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/base/PaketBaseIntegrationSpec.groovy
@@ -17,6 +17,9 @@
 
 package wooga.gradle.paket.base
 
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import spock.lang.Shared
+import spock.lang.Unroll
 import wooga.gradle.paket.PaketIntegrationBaseSpec
 import wooga.gradle.paket.get.PaketGetPlugin
 
@@ -38,5 +41,24 @@ class PaketBaseIntegrationSpec extends PaketIntegrationBaseSpec {
         return [PaketBasePlugin.INIT_TASK_NAME]
     }
 
+    @Shared
+    private List<String> paketDirectories = ["packages", ".paket", "paket-files"]
+
+    @Unroll
+    def "task :#taskToRun deletes paket directories"() {
+        given: "a directory with paket directories"
+        def paketDirectories = paketDirectories.collect { new File(projectDir, it) }
+        paketDirectories.each { it.mkdirs() }
+        assert paketDirectories.every { it.exists() && it.isDirectory() }
+
+        when:
+        runTasksSuccessfully(taskToRun)
+
+        then:
+        paketDirectories.every { !it.exists() }
+
+        where:
+        taskToRun = LifecycleBasePlugin.CLEAN_TASK_NAME
+    }
 
 }

--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
@@ -35,7 +35,6 @@ class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         return [
                 PaketGetPlugin.INSTALL_TASK_NAME,
                 PaketGetPlugin.UPDATE_TASK_NAME,
-                PaketGetPlugin.RESTORE_TASK_NAME,
                 PaketGetPlugin.OUTDATED_TASK_NAME
         ]
     }
@@ -58,7 +57,7 @@ class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         assert !packagesDir.exists()
 
         when:
-        def result = runTasksSuccessfully('paketInstall')
+        def result = runTasksSuccessfully(taskToRun)
 
         then: "paket runs and creates the packages directory"
         packagesDir.exists()
@@ -67,7 +66,7 @@ class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         result.standardOutput =~ /(?ms)Resolving packages for group Main:.*- $nuget/
 
         where:
-        taskToRun << bootstrapTestCases
+        taskToRun << [PaketGetPlugin.INSTALL_TASK_NAME, PaketGetPlugin.UPDATE_TASK_NAME]
     }
 
     @Unroll

--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
@@ -43,7 +43,7 @@ class PaketRestoreIntegrationSpec extends PaketIntegrationBaseSpec {
     private List<String> paketDirectories = ["packages", ".paket", "paket-files"]
 
     @Unroll
-    def "task :#taskToRun restores when deleting paket dir: #dirToDelete"() {
+    def "restores when #dirToDelete is missing"() {
         given: "a paket dependency file"
         createFile("paket.dependencies") << """
             source https://nuget.org/api/v2

--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
@@ -1,0 +1,116 @@
+package wooga.gradle.paket.get
+
+import spock.lang.Shared
+import spock.lang.Unroll
+import wooga.gradle.paket.PaketIntegrationBaseSpec
+
+class PaketRestoreIntegrationSpec extends PaketIntegrationBaseSpec {
+
+    def setup() {
+        buildFile << """
+            group = 'test'
+            ${applyPlugin(PaketGetPlugin)}
+        """.stripIndent()
+    }
+
+    @Override
+    Object getBootstrapTestCases() {
+        return [
+                PaketGetPlugin.RESTORE_TASK_NAME
+        ]
+    }
+
+    @Unroll
+    def "task :#taskToRun fails when paket.lock is missing"() {
+        given: "a paket dependency file"
+        createFile("paket.dependencies") << """
+            source https://nuget.org/api/v2
+            
+            nuget Mini
+        """.stripIndent()
+
+        when:
+        def result = runTasksWithFailure(taskToRun)
+
+        then:
+        result.standardError.contains("specified for property 'paketLock' does not exist")
+
+        where:
+        taskToRun << [PaketGetPlugin.RESTORE_TASK_NAME]
+    }
+
+    @Shared
+    private List<String> paketDirectories = ["packages", ".paket", "paket-files"]
+
+    @Unroll
+    def "task :#taskToRun restores when deleting paket dir: #dirToDelete"() {
+        given: "a paket dependency file"
+        createFile("paket.dependencies") << """
+            source https://nuget.org/api/v2
+            
+            nuget Mini
+        """.stripIndent()
+
+        and: "the future paket files"
+        def paketDirectories = paketDirectories.collect {new File(projectDir, it)}
+        def restoreCacheFile = new File(projectDir, "paket-files/paket.restore.cached")
+
+        and: "a paket install run to create the lock file and packages directory"
+        runTasksSuccessfully("paketInstall")
+
+        assert paketDirectories.every {it.exists()}
+        assert !restoreCacheFile.exists()
+
+        when: "deleting packages directory"
+        new File(projectDir, dirToDelete).delete()
+
+        and: "running paket restore"
+        runTasksSuccessfully(taskToRun)
+
+        then:
+        paketDirectories.every {it.exists()}
+        restoreCacheFile.exists()
+
+        where:
+        taskToRun = PaketGetPlugin.RESTORE_TASK_NAME
+        dirToDelete << paketDirectories
+    }
+
+    @Unroll
+    def "task :#taskToRun caches last restore state"() {
+        given: "a paket dependency file"
+        createFile("paket.dependencies") << """
+            source https://nuget.org/api/v2
+            
+            nuget Mini
+        """.stripIndent()
+
+        and: "the future paket files"
+        def restoreCacheFile = new File(projectDir, "paket-files/paket.restore.cached")
+
+        and: "a paket install run to create the lock file and packages directory"
+        runTasksSuccessfully("paketInstall")
+
+        and: "deleting packages directory"
+        new File(projectDir, "packages").delete()
+
+        and: "running paket restore"
+        runTasksSuccessfully(taskToRun)
+
+        when: "running restore again"
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        result.wasUpToDate(taskToRun)
+
+        when: "deleting the cache file"
+        restoreCacheFile.delete()
+        result = runTasksSuccessfully(taskToRun)
+
+        then:
+        !result.wasUpToDate(taskToRun)
+
+        where:
+        taskToRun = PaketGetPlugin.RESTORE_TASK_NAME
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/PaketBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/PaketBasePlugin.groovy
@@ -20,7 +20,10 @@ package wooga.gradle.paket.base
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.BasePlugin
+import org.gradle.api.tasks.Delete
 import org.gradle.buildinit.tasks.internal.TaskConfiguration
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import wooga.gradle.paket.base.internal.DefaultPaketPluginExtension
 import wooga.gradle.paket.base.tasks.internal.AbstractPaketTask
 import wooga.gradle.paket.base.tasks.PaketBootstrap
@@ -45,12 +48,13 @@ class PaketBasePlugin implements Plugin<Project> {
         this.project = project
 
         final extension = project.extensions.create(EXTENSION_NAME, DefaultPaketPluginExtension, project)
-
+        project.pluginManager.apply(LifecycleBasePlugin)
         configurePaketTasks(project, extension)
         addBootstrapTask(project, extension)
         addInitTask(project, extension)
         setConfigurations(project)
         setupPaketTasks(project)
+        setCleanTargets(project)
     }
 
     private static void setupPaketTasks(final Project project) {
@@ -106,12 +110,6 @@ class PaketBasePlugin implements Plugin<Project> {
         taskConvention.map("executable", { extension.getBootstrapperExecutable() })
         taskConvention.map("bootstrapURL", { extension.getPaketBootstrapperUrl() })
         taskConvention.map("paketVersion", { extension.getVersion() })
-
-        /*
-        taskConvention.map("outputFiles", {
-            project.files(extension.getExecutable(), extension.getBootstrapperExecutable())
-        })
-        */
     }
 
     private static void setConfigurations(final Project project) {
@@ -119,5 +117,10 @@ class PaketBasePlugin implements Plugin<Project> {
         def configuration = configurations.maybeCreate(PAKET_CONFIGURATION)
         configuration.description = "paket nupkg archive"
         configuration.transitive = false
+    }
+
+    private static void setCleanTargets(final Project project) {
+        final clean = project.tasks.getByName(LifecycleBasePlugin.CLEAN_TASK_NAME) as Delete
+        clean.delete(project.file("paket-files"), project.file("packages"), project.file(".paket"))
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/get/tasks/PaketRestore.groovy
+++ b/src/main/groovy/wooga/gradle/paket/get/tasks/PaketRestore.groovy
@@ -17,19 +17,40 @@
 
 package wooga.gradle.paket.get.tasks
 
-import wooga.gradle.paket.internal.PaketCommand
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
 import wooga.gradle.paket.base.tasks.internal.AbstractPaketTask
+import wooga.gradle.paket.internal.PaketCommand
 
 /**
  * A task to invoke {@code paket restore} command.
  */
 class PaketRestore extends AbstractPaketTask {
 
+    @InputFile
+    File getPaketLock() {
+        project.file("paket.lock")
+    }
+
+    @OutputFile
+    File getRestoreCacheOut() {
+        project.file("paket-files/paket.restore.cached")
+    }
 
     PaketRestore() {
         super(PaketRestore.class)
         description = "Download the dependencies specified by the paket.lock file into the packages/ directory."
         paketCommand = PaketCommand.RESTORE
-        outputs.upToDateWhen { false }
+        outputs.upToDateWhen(new Spec<PaketRestore>() {
+            @Override
+            boolean isSatisfiedBy(PaketRestore restore) {
+                if(!restore.getRestoreCacheOut().exists() || !restore.getPaketLock().exists()) {
+                    return false
+                }
+
+                restore.getPaketLock().text == restore.getRestoreCacheOut().text
+            }
+        })
     }
 }


### PR DESCRIPTION
## Description

We defined the `UP-TO-DATE` spec as always false for testing reasons in the past. This pull requests adds tests and `upToDateWhen` specs to mimic `paket restore`'s own update check.

This pull request brings also a change in the paket base plugin. Paket base will apply the `LifecycleBase` plugin to be able to adjust the `clean` task. The `clean` task will delete all paket generated directories: `.paket`, `packages` and `paket-files`.

resolves #34 

## Changes

![IMPROVE] `paketRestore` *UP-TO-DATE* check
![ADD] clean task and configure deletion of paket directories

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
