### PR TITLE
Fix exclude pattern for PaketUnityInstall task

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -114,7 +114,6 @@ class PaketUnityInstall extends ConventionTask {
             fileTree.include("packages/${nuget}/lib/${it}/**")
         })
 
-        fileTree.exclude("**/*.meta")
         fileTree.exclude("**/*.pdb")
         fileTree.exclude("**/Meta")
         fileTree.files
@@ -133,7 +132,7 @@ class PaketUnityInstall extends ConventionTask {
         if (!inputs.incremental) {
             if (getOutputDirectory().exists()) {
                 getOutputDirectory().deleteDir()
-                logger.quiet("delete target directory: ${getOutputDirectory()}")
+                logger.info("delete target directory: ${getOutputDirectory()}")
                 assert !getOutputDirectory().exists()
             }
         }
@@ -142,7 +141,7 @@ class PaketUnityInstall extends ConventionTask {
             @Override
             void execute(InputFileDetails outOfDate) {
                 def outputPath = transformInputToOutputPath(outOfDate.file, project.file("packages"))
-                logger.quiet("${outOfDate.added ? "install" : "update"}: ${outputPath}")
+                logger.info("${outOfDate.added ? "install" : "update"}: ${outputPath}")
                 FileUtils.copyFile(outOfDate.file, outputPath)
                 assert outputPath.exists()
             }
@@ -151,14 +150,14 @@ class PaketUnityInstall extends ConventionTask {
         inputs.removed(new Action<InputFileDetails>() {
             @Override
             void execute(InputFileDetails removed) {
-                logger.quiet("remove: ${removed.file}")
+                logger.info("remove: ${removed.file}")
                 removed.file.delete()
                 def outputPath = transformInputToOutputPath(removed.file, project.file("packages"))
                 outputPath.delete()
 
                 File parent = outputPath.parentFile
                 while (parent.isDirectory() && parent.listFiles().toList().empty) {
-                    logger.quiet("Garbage collecting: ${removed.file}")
+                    logger.info("Garbage collecting: ${removed.file}")
                     parent.deleteDir()
                     parent = parent.parentFile
                 }


### PR DESCRIPTION
## Description

The new paket unity implementation is excluding __.meta__ files. This
pull requests adds these files back to be copied. Also adjusts the log
level for the unity install task.

## Changes

![REMOVE] __.meta__ from exclude filter
![IMPROVE] log output

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
