### PR TITLE
Cache paket.bootstrapper.exe and paket.exe during integration tests

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
@@ -17,13 +17,58 @@
 
 package wooga.gradle.paket
 
+import org.apache.commons.io.FileUtils
+import spock.lang.Shared
+
 class IntegrationSpec extends nebula.test.IntegrationSpec{
+
+    @Shared
+    File cachedPaketDir
+
+    def setupSpec() {
+        cachedPaketDir = File.createTempDir("paket","cache")
+        cachedPaketDir.deleteOnExit()
+    }
+
+    def cleanupSpec() {
+        cachedPaketDir.deleteDir()
+    }
+
+    def getPaketDir() {
+        new File(projectDir, ".paket")
+    }
 
     def setup() {
         def gradleVersion = System.getenv("GRADLE_VERSION")
         if (gradleVersion) {
             this.gradleVersion = gradleVersion
             fork = true
+        }
+
+        if(isValidPaketDirectory(cachedPaketDir)) {
+            FileUtils.copyDirectory(cachedPaketDir, paketDir)
+        }
+    }
+
+    Boolean isValidPaketDirectory(File dir) {
+        File bootstrapper = new File(dir, "paket.bootstrapper.exe")
+        File paket = new File(dir, "paket.exe")
+        bootstrapper.exists() && paket.exists()
+    }
+
+    void cleanupPaketDirectory() {
+        File paketDir = paketDir
+        if(paketDir.exists() && paketDir.isDirectory()) {
+            paketDir.deleteDir()
+        }
+    }
+
+    def cleanup() {
+        //copy the .paket folder to cache directory
+        File paketDir = paketDir
+
+        if( isValidPaketDirectory(paketDir) ) {
+            FileUtils.copyDirectory(paketDir, cachedPaketDir)
         }
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
@@ -42,7 +42,7 @@ abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
         def paketDir = new File(projectDir, '.paket')
         def paketBootstrap = new File(paketDir, bootstrapperFileName)
         def paket = new File(paketDir, 'paket.exe')
-
+        cleanupPaketDirectory()
         assert !paketDir.exists()
 
         when:
@@ -67,6 +67,7 @@ abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
         createFile("paket.lock")
 
         and: "a first run of #taskToRun"
+        cleanupPaketDirectory()
         runTasksSuccessfully(taskToRun)
 
         when: "running a second time without changes"


### PR DESCRIPTION
## Description

We constantly hit a rate limit when running the integration tests for this gradle plugin. I don't want to bundle _Paket_ resources with this plugin and also no special test setup or logic execute during the tests. This is why I implemented a cache for each test spec. We run roughly 110 test features and each time we download the paket resources. The new test logic hooks itself into the `cleanup` method for each spec and copies the generated `.paket` folder to a temp directory. Another hook in `setup` phase will check if the paket resources are available in this temp folder and copy it before execution. This means no code duplication for downloading the resources and no adjustments to the base plugin code. If for whatever reason the cache directory is empty the test code will download the resources anyway.

There is one set of tests that need a clean test setup. For these tests I added a helper function to delete the resources.

## Changes

![IMPROVE] test stability by caching paket resources

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
