### PR TITLE
Fix paket.lock file parser

### DIFF
--- a/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketLockSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketLockSpec.groovy
@@ -8,52 +8,70 @@ class PaketLockSpec extends Specification {
 
     static String LOCK_CONTENT = """
     NUGET
-      remote: https://wooga.artifactoryonline.com/wooga/api/nuget/atlas-nuget
-        NSubstitute (1.9.1.0)
-        Substance (0.0.10-beta)
-        Substance.Collections (0.0.10-beta)
-          Substance (>= 0.0.10-beta)
-        Substance.Collections.Generic (0.0.10-beta)
-          Substance (>= 0.0.10-beta)
-          Substance.Collections (>= 0.0.10-beta)
-        Substance.Collections.Immutable (0.0.10-beta)
-          Substance (>= 0.0.10-beta)
-          Substance.Collections (>= 0.0.10-beta)
-          Substance.Collections.Generic (>= 0.0.10-beta)
-        Wooga.AtlasBuildTools (1.0.0)
-        Wooga.Lambda (0.7.0)
-          Substance.Collections.Immutable (>= 0.0.0-beta)
-        Wooga.XCodeEditor (3.1.3)
-          Wooga.JsonDotNetNode (>= 0.1.0-prerelease < 0.2.0-prerelease)
-      remote: https://wooga.artifactoryonline.com/wooga/api/nuget/atlas-nuget-snapshot
-        Wooga.JsonDotNetNode (0.1.1-master00001)
+      remote: https://a.repo.com
+        A (0.0.10-beta)
+        W.A (3.0.0-rc00001)
+          W.S (>= 3.0.0-rc)
+        W.E (1.0.0)
+        W.N (0.1.0)
+        W.S (3.0.1)
+          W.J (>= 0.1.0-prerelease < 0.2.0-prerelease)
+          W.L (>= 0.7 < 1.0)
+      remote: https://www.nuget.org/api/v2
+        A.C (0.0.10-beta)
+          A (>= 0.0.10-beta)
+        A.C.G (0.0.10-beta)
+          A (>= 0.0.10-beta)
+          A.C (>= 0.0.10-beta)
+        A.C.I (0.0.10-beta)
+          A (>= 0.0.10-beta)
+          A.C (>= 0.0.10-beta)
+          A.C.G (>= 0.0.10-beta)
+        W.L (0.7)
+          A.C.I (>= 0.0.0-beta)
+      remote: https://a.repo.com/snapshot
+        W.J (0.1.1-master00001)
     """.stripIndent()
 
-    static String LOCK_CONTENT_2 = """
+    static String MULTI_TYPE_LOCK_CONTENT = """
+    ${LOCK_CONTENT}
+
+    GITHUB
+      remote: fsharp/FAKE
+        modules/Octokit/Octokit.fsx (a25c2f256a99242c1106b5a3478aae6bb68c7a93)
+          Octokit (>= 0)
+    GIT
+      remote: https://github.com/forki/nupkgtest.git
+        (05366e390e7552a569f3f328a0f3094249f3b93b)
+    HTTP
+      remote: http://www.fssnip.net/raw/1M/test1.fs
+      test1.fs    
+    """.stripIndent()
+
+    static String LOCK_CONTENT_BROKEN_TYPE = """
+    NUGIT
+      remote: https://a.repo.com
+        A (0.0.10-beta)
+        W.A (3.0.0-rc00001)
+          W.S (>= 3.0.0-rc)
+        W.E (1.0.0)
+        W.N (0.1.0)
+        W.S (3.0.1)
+          W.J (>= 0.1.0-prerelease < 0.2.0-prerelease)
+          W.L (>= 0.7 < 1.0)
+    """.stripIndent()
+
+    static String LOCK_CONTENT_BROKEN_INDENTION = """
     NUGET
-      remote: https://wooga.artifactoryonline.com//wooga/api/nuget/atlas-nuget
-        Substance (0.0.10-beta)
-        Wooga.AssetBundleManager (3.0.0-rc00001)
-          Wooga.Services (>= 3.0.0-rc)
-        Wooga.EditorSpotlight (1.0.0)
-        Wooga.NativeShare (0.1.0)
-        Wooga.Services (3.0.1)
-          Wooga.JsonDotNetNode (>= 0.1.0-prerelease < 0.2.0-prerelease)
-          Wooga.Lambda (>= 0.7 < 1.0)
-      remote: https://www.nuget.org/api/v2
-        Substance.Collections (0.0.10-beta)
-          Substance (>= 0.0.10-beta)
-        Substance.Collections.Generic (0.0.10-beta)
-          Substance (>= 0.0.10-beta)
-          Substance.Collections (>= 0.0.10-beta)
-        Substance.Collections.Immutable (0.0.10-beta)
-          Substance (>= 0.0.10-beta)
-          Substance.Collections (>= 0.0.10-beta)
-          Substance.Collections.Generic (>= 0.0.10-beta)
-        Wooga.Lambda (0.7)
-          Substance.Collections.Immutable (>= 0.0.0-beta)
-      remote: https://wooga.artifactoryonline.com//wooga/api/nuget/atlas-nuget-snapshot
-        Wooga.JsonDotNetNode (0.1.1-master00001)
+        remote: https://a.repo.com
+            A (0.0.10-beta)
+            W.A (3.0.0-rc00001)
+                W.S (>= 3.0.0-rc)
+            W.E (1.0.0)
+            W.N (0.1.0)
+            W.S (3.0.1)
+                W.J (>= 0.1.0-prerelease < 0.2.0-prerelease)
+                W.L (>= 0.7 < 1.0)
     """.stripIndent()
 
     @Shared
@@ -76,14 +94,16 @@ class PaketLockSpec extends Specification {
         def lock = new PaketLock(content)
 
         then:
-        def nugets = lock.getDependencies(PaketLock.SourceType.NUGET, "Wooga.XCodeEditor")
+        def nugets = lock.getDependencies(PaketLock.SourceType.NUGET, "W.A")
         nugets.size() == 1
-        nugets.contains("Wooga.JsonDotNetNode")
+        nugets.contains("W.S")
 
         where:
         objectType | content
-        "String"   | LOCK_CONTENT
-        "File"     | lockFile << LOCK_CONTENT
+        "String"            | LOCK_CONTENT
+        "File"              | lockFile << LOCK_CONTENT
+        "multi type String" | MULTI_TYPE_LOCK_CONTENT
+        "multi type File"   | lockFile << MULTI_TYPE_LOCK_CONTENT
     }
 
     @Unroll
@@ -101,12 +121,36 @@ class PaketLockSpec extends Specification {
         nugets.size() == expectedDependencies.size()
 
         where:
-        objectType | content
-        "String"   | LOCK_CONTENT_2
-        "File"     | lockFile << LOCK_CONTENT_2
+        objectType          | content
+        "String"            | LOCK_CONTENT
+        "File"              | lockFile << LOCK_CONTENT
+        "multi type String" | MULTI_TYPE_LOCK_CONTENT
+        "multi type File"   | lockFile << MULTI_TYPE_LOCK_CONTENT
 
-        references = ["Wooga.Services", "Wooga.AssetBundleManager", "Wooga.NativeShare", "Wooga.EditorSpotlight"]
-        expectedDependencies = references + ["Substance","Substance.Collections","Substance.Collections.Immutable", "Substance.Collections.Generic", "Wooga.Lambda", "Wooga.JsonDotNetNode"]
+        references = ["W.S", "W.A", "W.N", "W.E"]
+        expectedDependencies = references + ["A", "A.C", "A.C.I", "A.C.G", "W.L", "W.J"]
+    }
+
+    @Unroll
+    def "fails to expand when dependency file has #failure"() {
+        when:
+        def lock = new PaketLock(content)
+
+        then:
+        def nugets = lock.getAllDependencies(references)
+
+        expectedDependencies.every {
+            nugets.contains(it)
+        }
+
+        nugets.size() == expectedDependencies.size()
+
+        where:
+        failure           | content
+        "broken type"     | LOCK_CONTENT_BROKEN_TYPE
+        "wrong indention" | LOCK_CONTENT_BROKEN_INDENTION
+        references = ["A"]
+        expectedDependencies = references
     }
 
 }

--- a/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketLockSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketLockSpec.groovy
@@ -29,6 +29,33 @@ class PaketLockSpec extends Specification {
         Wooga.JsonDotNetNode (0.1.1-master00001)
     """.stripIndent()
 
+    static String LOCK_CONTENT_2 = """
+    NUGET
+      remote: https://wooga.artifactoryonline.com//wooga/api/nuget/atlas-nuget
+        Substance (0.0.10-beta)
+        Wooga.AssetBundleManager (3.0.0-rc00001)
+          Wooga.Services (>= 3.0.0-rc)
+        Wooga.EditorSpotlight (1.0.0)
+        Wooga.NativeShare (0.1.0)
+        Wooga.Services (3.0.1)
+          Wooga.JsonDotNetNode (>= 0.1.0-prerelease < 0.2.0-prerelease)
+          Wooga.Lambda (>= 0.7 < 1.0)
+      remote: https://www.nuget.org/api/v2
+        Substance.Collections (0.0.10-beta)
+          Substance (>= 0.0.10-beta)
+        Substance.Collections.Generic (0.0.10-beta)
+          Substance (>= 0.0.10-beta)
+          Substance.Collections (>= 0.0.10-beta)
+        Substance.Collections.Immutable (0.0.10-beta)
+          Substance (>= 0.0.10-beta)
+          Substance.Collections (>= 0.0.10-beta)
+          Substance.Collections.Generic (>= 0.0.10-beta)
+        Wooga.Lambda (0.7)
+          Substance.Collections.Immutable (>= 0.0.0-beta)
+      remote: https://wooga.artifactoryonline.com//wooga/api/nuget/atlas-nuget-snapshot
+        Wooga.JsonDotNetNode (0.1.1-master00001)
+    """.stripIndent()
+
     @Shared
     File lockFile = File.createTempFile("paket", ".lock")
 
@@ -57,6 +84,29 @@ class PaketLockSpec extends Specification {
         objectType | content
         "String"   | LOCK_CONTENT
         "File"     | lockFile << LOCK_CONTENT
+    }
+
+    @Unroll
+    def "parses all nuget dependencies from paket.lock with #objectType"() {
+        when:
+        def lock = new PaketLock(content)
+
+        then:
+        def nugets = lock.getAllDependencies(references)
+
+        expectedDependencies.every {
+            nugets.contains(it)
+        }
+
+        nugets.size() == expectedDependencies.size()
+
+        where:
+        objectType | content
+        "String"   | LOCK_CONTENT_2
+        "File"     | lockFile << LOCK_CONTENT_2
+
+        references = ["Wooga.Services", "Wooga.AssetBundleManager", "Wooga.NativeShare", "Wooga.EditorSpotlight"]
+        expectedDependencies = references + ["Substance","Substance.Collections","Substance.Collections.Immutable", "Substance.Collections.Generic", "Wooga.Lambda", "Wooga.JsonDotNetNode"]
     }
 
 }


### PR DESCRIPTION
## Description

The `paket.lock` file parser has issues with counting leading whitespaces. The value from the old logic `def newLeadingWhitespaces =(line =~ /\s/).size()` returns the number of all white space characters in the current line.

The second part:

```groovy
if (newLeadingWhitespaces > currentLeadingWhitespaces) {
  currentIndent++
} else if (newLeadingWhitespaces < currentLeadingWhitespaces) {
  currentIndent--
}
```

didn't take into account when the indention level suddenly jumped from 3 to 1. I also made the method `List<String> getAllDependencies(List<String> references)` recursive. I added a new test covering the failing behavior

## Changes

![FIX] `paket.lock` file parsing
![IMPROVE] `getAllDependencies` method by making it recursive
![ADD] new test example

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
