### PR TITLE
Feature dependency definition in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,4 +68,6 @@ dependencies {
     testCompile('org.jfrog.artifactory.client:artifactory-java-client-services:2.+') {
         exclude module: 'logback-classic'
     }
+
+    compile('com.google.guava:guava:19.0')
 }

--- a/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
@@ -18,12 +18,25 @@
 package wooga.gradle.paket
 
 import org.apache.commons.io.FileUtils
+import org.apache.commons.lang.StringEscapeUtils
 import spock.lang.Shared
 
 class IntegrationSpec extends nebula.test.IntegrationSpec{
 
     @Shared
     File cachedPaketDir
+
+    def escapedPath(String path) {
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            return StringEscapeUtils.escapeJava(path)
+        }
+        path
+    }
+
+    def convertToWindowsPath(String path) {
+        new File(path).toString()
+    }
 
     def setupSpec() {
         cachedPaketDir = File.createTempDir("paket","cache")

--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.paket
 import nebula.test.functional.ExecutionResult
 import spock.lang.Shared
 import spock.lang.Unroll
+import wooga.gradle.paket.base.PaketBasePlugin
 
 abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
 
@@ -53,6 +54,18 @@ abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
         paketDir.exists()
         paketBootstrap.exists()
         paket.exists()
+
+        where:
+        taskToRun << bootstrapTestCases
+    }
+
+    @Unroll
+    def "task :paketBootstrap calls :paketDependencies when runing #taskToRun"(String taskToRun) {
+        when:
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        result.wasExecuted(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
 
         where:
         taskToRun << bootstrapTestCases

--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationDependencyFileSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationDependencyFileSpec.groovy
@@ -155,7 +155,5 @@ abstract class PaketIntegrationDependencyFileSpec extends PaketIntegrationBaseSp
         then: "evaluate incremental task execution"
         result.wasExecuted("paketInstall")
         result.wasExecuted(PaketUnityPlugin.INSTALL_TASK_NAME)
-
-
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/paket/base/dependencies/PaketNugetDependenciesIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/base/dependencies/PaketNugetDependenciesIntegrationSpec.groovy
@@ -1,0 +1,434 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies
+
+import spock.lang.Unroll
+import wooga.gradle.paket.IntegrationSpec
+import wooga.gradle.paket.base.PaketBasePlugin
+import wooga.gradle.paket.get.PaketGetPlugin
+
+class PaketNugetDependenciesIntegrationSpec extends IntegrationSpec {
+    def setup() {
+        buildFile << """
+            group = 'test'
+            ${applyPlugin(PaketGetPlugin)}
+        """.stripIndent()
+    }
+
+    static String NUGET_VERSION_STRING = """
+
+    nuget "Wooga.Test ~> 3"
+
+    """.stripIndent()
+
+    static String NUGET_CONFIG_CLOSURE = """
+    nuget("Wooga.Test") {
+        version "~> 3"
+    }
+    """.stripIndent()
+
+    static String NUGET_CONFIG_CLOSURE_2 = """
+    nuget("Wooga.Test = 2.0.0") {
+        version "~> 3"
+    }
+    """.stripIndent()
+
+    static String NUGET_WITHOUT_VERSION = """
+
+    nuget "Wooga.Test"
+
+    """.stripIndent()
+
+    static String ADD_NUGET_STRING = """
+
+    add "nuget Wooga.Test ~> 3"
+
+    """.stripIndent()
+
+    static String ADD_NUGET_STRING_NO_VERSION = """
+
+    add "nuget Wooga.Test"
+
+    """.stripIndent()
+
+    static String ADD_NUGET_STRING_NO_VERSION_CLOSURE = """
+
+    add("nuget Wooga.Test") {
+        version "~> 3"
+    }
+
+    """.stripIndent()
+
+    static String ADD_NUGET_STRING_NO_VERSION_CLOSURE_2 = """
+
+    add("nuget Wooga.Test = 2.0.0") {
+        version "~> 3"
+    }
+
+    """.stripIndent()
+
+    static String NUGET_MAIN_GROUP = """
+    main { 
+        nuget "Wooga.Test ~> 3"
+    }
+    """.stripIndent()
+
+    static String NUGET_CUSTOM_GROUP = """
+    custom { 
+        nuget "Wooga.Test ~> 3"
+    }
+    """.stripIndent()
+
+    @Unroll
+    def "user can define dependencies with [#definition] in build.gradle"() {
+        given: "a build file with one nuget dependency defined"
+        buildFile << """
+        dependencies {
+            paket {
+                ${definition}
+            }
+        }
+        """.stripIndent()
+
+        and: "a future paket.dependencies file"
+        File paketDependencies = new File(projectDir, 'paket.dependencies')
+        assert !paketDependencies.exists()
+
+        when:
+        runTasksSuccessfully("paketDependencies")
+
+        then:
+        paketDependencies.exists()
+        def regex = '^' + expectedNugetLine + '$'
+        paketDependencies.text.readLines().any { it.matches(regex) }
+
+        where:
+        definition                            | expectedNugetLine
+        NUGET_VERSION_STRING                  | "nuget Wooga.Test ~> 3"
+        NUGET_CONFIG_CLOSURE                  | "nuget Wooga.Test ~> 3"
+        NUGET_CONFIG_CLOSURE_2                | "nuget Wooga.Test ~> 3"
+        ADD_NUGET_STRING                      | "nuget Wooga.Test ~> 3"
+        ADD_NUGET_STRING_NO_VERSION           | "nuget Wooga.Test"
+        ADD_NUGET_STRING_NO_VERSION_CLOSURE   | "nuget Wooga.Test ~> 3"
+        ADD_NUGET_STRING_NO_VERSION_CLOSURE_2 | "nuget Wooga.Test ~> 3"
+        NUGET_MAIN_GROUP                      | "nuget Wooga.Test ~> 3"
+        NUGET_CUSTOM_GROUP                    | "    nuget Wooga.Test ~> 3"
+        NUGET_WITHOUT_VERSION                 | "nuget Wooga.Test"
+    }
+
+    static String NUGET_SOURCE_WITHOUT_CREDENTIALS = """
+    nuget {
+        url "https://wooga.jfrog.io/wooga/api/nuget/atlas-nuget-snapshot"        
+    }
+    """.stripIndent()
+
+    static String NUGET_SOURCE_WITH_CREDENTIALS = """
+    nuget {
+        url "https://wooga.jfrog.io/wooga/api/nuget/atlas-nuget-snapshot"
+        credentials {
+            username = "foo"
+            password = "bar"
+        }
+        
+    }
+    """.stripIndent()
+
+    @Unroll
+    def "user can define dependencies source #type"() {
+        given: "a build file with one nuget dependency defined"
+        buildFile << """
+        dependencies {
+            paket {
+                nuget "Wooga.Test"
+            }
+        }
+        """.stripIndent()
+
+        and: "a custom nuget repository"
+        buildFile << """
+        repositories {
+            ${value}   
+        }
+        """.stripIndent()
+
+        and: "a future paket.dependencies file"
+        File paketDependencies = new File(projectDir, 'paket.dependencies')
+        assert !paketDependencies.exists()
+
+        when:
+        runTasksSuccessfully("paketDependencies")
+
+        then:
+        paketDependencies.exists()
+        def regex = '^' + expectedSourceValue + '$'
+        paketDependencies.text.readLines().any { it.matches(regex) }
+
+        where:
+        type                      | value                            | expectedSourceValue
+        "url without credentials" | NUGET_SOURCE_WITHOUT_CREDENTIALS | "source https://wooga.jfrog.io/wooga/api/nuget/atlas-nuget-snapshot"
+        "url with credentials"    | NUGET_SOURCE_WITH_CREDENTIALS    | "source https://wooga.jfrog.io/wooga/api/nuget/atlas-nuget-snapshot username: \"foo\" password: \"bar\""
+    }
+
+    static String NUGET_SOURCE_SINGLE_DIR = """
+    nuget {
+        dir "../path/to/source/one"
+    }
+
+    nuget {
+        dir "../path/to/source/two"                
+    }
+    """.stripIndent()
+
+    static String NUGET_SOURCE_MULTI_DIR = """ 
+    nuget {
+        dir "../path/to/source/one"
+        dir "../path/to/source/two"
+    }
+    """.stripIndent()
+
+    static String NUGET_SOURCE_MULTI_DIR_2 = """
+    nuget {
+        dirs "../path/to/source/one", "../path/to/source/two"
+    }
+    """.stripIndent()
+
+    @Unroll
+    def "user can define #type"() {
+        given: "a build file with one nuget dependency defined"
+        buildFile << """
+        dependencies {
+            paket {
+                nuget "Wooga.Test"
+            }
+        }
+        """.stripIndent()
+
+        and: "a custom nuget repository"
+        buildFile << """
+        repositories {
+            ${value}
+        }
+        """.stripIndent()
+
+        and: "a future paket.dependencies file"
+        File paketDependencies = new File(projectDir, 'paket.dependencies')
+        assert !paketDependencies.exists()
+
+        when:
+        runTasksSuccessfully("paketDependencies")
+
+        then:
+        paketDependencies.exists()
+        paketDependencies.text.contains("source ${convertToWindowsPath('../path/to/source/one')}")
+        paketDependencies.text.contains("source ${convertToWindowsPath('../path/to/source/two')}")
+
+        where:
+
+        type                                      | value
+        "single directory per repository"         | NUGET_SOURCE_SINGLE_DIR
+        "multiple directories per repository"     | NUGET_SOURCE_MULTI_DIR
+        "multiple directories in one instruction" | NUGET_SOURCE_MULTI_DIR_2
+    }
+
+    @Unroll
+    def "user can restrict frameworks with #type"() {
+        given: "a build file with one nuget dependency defined and framework restriction"
+        buildFile << """
+        dependencies {
+            paket {
+                ${value}
+                nuget "Wooga.Test"
+            }
+        }
+        """.stripIndent()
+
+        and: "a future paket.dependencies file"
+        File paketDependencies = new File(projectDir, 'paket.dependencies')
+        assert !paketDependencies.exists()
+
+        when:
+        runTasksSuccessfully("paketDependencies")
+
+        then:
+        paketDependencies.exists()
+        paketDependencies.text.contains(expectedFrameworkRestriction)
+
+        where:
+        type                                       | value                                                 | expectedFrameworkRestriction
+        "a single framework"                       | "framework 'net35'"                                   | "framework: net35"
+        "multiple frameworks with one call"        | "frameworks 'net35', 'net40'"                         | "framework: net35, net40"
+        "multiple frameworks as array"             | 'frameworks(["net35", "net40", "monomac"])'           | "framework: net35, net40, monomac"
+        "multiple frameworks as array with setter" | 'frameworks = ["net35", "net40"]'                     | "framework: net35, net40"
+        "multiple frameworks single calls"         | "framework 'net40'; framework 'monomac'"              | "framework: net40, monomac"
+        "reset frameworks with setter"             | "frameworks 'net35', 'net40'; frameworks=['monomac']" | "framework: monomac"
+    }
+
+    @Unroll
+    def ":paketDependencies #method paket.dependencies file when executed and dependencies are configured"() {
+        given: "a project with dependencies defined in build.gradle"
+        buildFile << """
+        dependencies {
+            paket {
+                nuget "Wooga.Test"
+            }
+        }
+        """.stripIndent()
+        and: "optional created paket.dependencies file"
+        def dependenciesFile = new File(projectDir, 'paket.dependencies')
+        if (createDependenciesFile) {
+            dependenciesFile << """
+            //empty dependencies file
+            """
+        }
+
+        when:
+        def result = runTasksSuccessfully(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+
+        then:
+        !result.wasSkipped(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+        dependenciesFile.exists()
+        !dependenciesFile.text.contains("//empty dependencies file")
+
+        where:
+        createDependenciesFile << [true, false]
+        method << ["overrides", "creates"]
+    }
+
+    def ":paketDependencies skips when no internal dependencies are configured"() {
+        expect:
+        runTasksSuccessfully(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME).wasSkipped(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+    }
+
+    def ":paketDependencies is upToData when internal dependencies are configured and run multiple times"() {
+        given: "a project with dependencies defined in build.gradle"
+        buildFile << """
+        dependencies {
+            paket {
+                nuget "Wooga.Test"
+            }
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+
+        then:
+        result.wasExecuted(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+        !result.wasUpToDate(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+
+        when:
+        result = runTasksSuccessfully(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+
+        then:
+        result.wasUpToDate(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+    }
+
+    @Unroll
+    def ":paketDependencies runs again after #type"() {
+        given: "a project with dependencies defined in build.gradle"
+
+        buildFile << """
+        dependencies {
+            paket {
+                nuget "Wooga.Test"
+            }
+        }
+        
+        repositories {
+            nuget { 
+                name 'test'
+                url 'some/url'
+            } 
+        }
+        """.stripIndent()
+
+        and: "a gradle run to make task UP-TO-DATE"
+        def result = runTasksSuccessfully(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+        assert result.wasExecuted(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+        assert !result.wasUpToDate(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+        result = runTasksSuccessfully(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+        assert result.wasUpToDate(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+
+        when: "reconfigure"
+        buildFile << """
+        ${reconfigure}
+        """.stripIndent()
+
+        result = runTasksSuccessfully(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+
+        then:
+        result.wasExecuted(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+        !result.wasUpToDate(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+
+        where:
+        type                   | reconfigure
+        "add a dependency"     | "dependencies.paket { nuget 'Wooga.Test2' }"
+        "replace a dependency" | "dependencies.paket.clear(); dependencies.paket { nuget 'Wooga.Test2' }"
+        "add a source"         | "repositories { nuget { name 'foo'; url 'some/url' } }"
+        "replace a source"     | "repositories.clear(); repositories.nuget { url 'url' }"
+        "add a macro"          | "dependencies.paket { framework 'net35' }"
+        "replace a macro"      | "dependencies.paket { frameworks=['net40'] }"
+
+    }
+
+    def "fails creating group when group identifier is not valid"() {
+        given: "a project with dependencies defined in build.gradle"
+
+        buildFile << """
+        dependencies {
+            paket {
+                1group {
+                    nuget "Wooga.Test"
+                }
+            }
+        }
+        """.stripIndent()
+
+        expect:
+        def result = runTasksWithFailure(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+        result.standardError.contains("No signature of method")
+    }
+
+    @Unroll
+    def "can retrieve and configure #groupName group"() {
+        given: "a project with dependencies defined in build.gradle"
+
+        buildFile << """
+        
+        def testGroup = dependencies.paket['${groupName}']
+        testGroup.configure {
+            nuget "Wooga.Test"
+        }
+        
+        """.stripIndent()
+
+        and: "a future paket.dependencies file"
+        File paketDependencies = new File(projectDir, 'paket.dependencies')
+        assert !paketDependencies.exists()
+
+        when:
+        def result = runTasksSuccessfully(PaketBasePlugin.PAKET_DEPENDENCIES_TASK_NAME)
+
+        then:
+        paketDependencies.exists()
+        paketDependencies.text.contains("nuget Wooga.Test")
+
+        where:
+        groupName << ["custom","main"]
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/PaketPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/PaketPluginExtension.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.paket.base
 
+import wooga.gradle.paket.base.dependencies.PaketDependencyHandler
 import wooga.gradle.paket.base.utils.PaketDependencies
 
 /**
@@ -196,4 +197,6 @@ interface PaketPluginExtension {
      * @see     PaketDependencies
      */
     PaketDependencies getPaketDependencies()
+
+    PaketDependencyHandler getDependencyHandler()
 }

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/NugetDependency.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/NugetDependency.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Wooga GmbH
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@
  *
  */
 
-package wooga.gradle.paket.publish.repository
+package wooga.gradle.paket.base.dependencies
 
-interface NugetRepositoryHandlerConvention extends wooga.gradle.paket.base.repository.NugetRepositoryHandlerConvention<NugetArtifactRepository> {
+interface NugetDependency extends PaketDependency {
 
 }

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependency.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependency.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies
+
+import org.gradle.api.Named
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+interface PaketDependency extends Dependency, Named {
+
+    /**
+     * Returns the {@code String} representation in the paket format.
+     *
+     * @return
+     */
+    String toString()
+
+    @Optional
+    @Input
+    String getName()
+
+    @Optional
+    @Input
+    String getVersion()
+
+    @Input
+    /**
+     * Returns the type of the dependency
+     *
+     * One of
+     * - nuget
+     * - clitool
+     * - github
+     * - git
+     * - gist
+     * - http
+     *
+     * @return
+     */
+    PaketDependencyType getType()
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyConfiguration.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies
+
+import org.gradle.api.Named
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectSet
+import org.gradle.api.tasks.Nested
+import org.gradle.util.Configurable
+
+interface PaketDependencyConfiguration extends PaketDependencyConfigurationHandler, NamedDomainObjectSet<PaketDependency>, Configurable<NamedDomainObjectContainer<PaketDependency>>, Named {
+
+    @Nested
+    SortedMap<String, PaketDependency> getAsMap()
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyConfigurationContainer.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyConfigurationContainer.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Wooga GmbH
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,12 @@
  *
  */
 
-package wooga.gradle.paket.publish.repository
+package wooga.gradle.paket.base.dependencies
 
-interface NugetRepositoryHandlerConvention extends wooga.gradle.paket.base.repository.NugetRepositoryHandlerConvention<NugetArtifactRepository> {
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.tasks.Nested
 
+interface PaketDependencyConfigurationContainer extends NamedDomainObjectContainer<PaketDependencyConfiguration> {
+    @Nested
+    SortedMap<String, PaketDependencyConfiguration> getAsMap()
 }

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyConfigurationHandler.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyConfigurationHandler.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies
+
+import org.gradle.api.Action
+
+/**
+ * A handler object to add and configure paket dependency configurations.
+ */
+interface PaketDependencyConfigurationHandler {
+
+    /**
+     * Adds a paket dependency.
+     *
+     * @param dependencyNotation a valid paket dependency notation.
+     * @return {@code true} if dependency was added to the configuration
+     */
+    boolean add(final String dependencyNotation)
+
+    /**
+     * Adds a paket dependency and configures it with the given closure.
+     *
+     * @param dependencyNotation a valid paket dependency notation.
+     * @param depSpec a {@code Closure} to configure the created {@link PaketDependency}
+     * @return {@code true} if dependency was added to the configuration
+     */
+    boolean add(final String dependencyNotation, Closure depSpec)
+
+    /**
+     * Adds a paket dependency and configures it with the given action.
+     *
+     * @param dependencyNotation a valid paket dependency notation.
+     * @param depSpec a {@code Action} to configure the created {@link PaketDependency}
+     * @return {@code true} if dependency was added to the configuration
+     */
+    boolean add(final String dependencyNotation, Action<PaketDependency> depSpec)
+
+    /**
+     * Adds a {@link wooga.gradle.paket.base.dependencies.internal.DefaultNugetDependency}.
+     *
+     * @param dependencyNotation a valid nuget dependency notation.
+     * @return {@code true} if dependency was added to the configuration
+     */
+    boolean nuget(final String dependencyNotation)
+
+    /**
+     * Adds a {@link wooga.gradle.paket.base.dependencies.internal.DefaultNugetDependency}.
+     *
+     * @param dependencyNotation a valid nuget dependency notation.
+     * @param depSpec a {@code Closure} to configure the created {@link wooga.gradle.paket.base.dependencies.internal.DefaultNugetDependency}
+     * @return {@code true} if dependency was added to the configuration
+     */
+    boolean nuget(String dependencyNotation, Closure depSpec)
+
+    /**
+     * Adds a {@link wooga.gradle.paket.base.dependencies.internal.DefaultNugetDependency}.
+     *
+     * @param dependencyNotation a valid nuget dependency notation.
+     * @param depSpec a {@code Action} to configure the created {@link wooga.gradle.paket.base.dependencies.internal.DefaultNugetDependency}
+     * @return {@code true} if dependency was added to the configuration
+     */
+    boolean nuget(String dependencyNotation, Action<PaketDependency> depSpec)
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyFormatException.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyFormatException.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Wooga GmbH
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,17 @@
  *
  */
 
-package wooga.gradle.paket.publish.repository
+package wooga.gradle.paket.base.dependencies
 
-interface NugetRepositoryHandlerConvention extends wooga.gradle.paket.base.repository.NugetRepositoryHandlerConvention<NugetArtifactRepository> {
+import groovy.transform.CompileStatic
 
+/**
+ * {@Exception} class for incorrect formats of Paket dependencies.
+ */
+@CompileStatic
+class PaketDependencyFormatException extends Exception {
+
+    PaketDependencyFormatException(final String msg) {
+        super(msg)
+    }
 }

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyFrameworkMacro.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyFrameworkMacro.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies
+
+import org.gradle.api.tasks.Input
+
+interface PaketDependencyFrameworkMacro {
+
+    /**
+     * Returns a list of restricted frameworks
+     * @return
+     */
+    @Input
+    List<String> getFrameworks()
+
+    /**
+     * Sets the list of restricted frameworks as @{Iterable<String>}
+     * @param frameworks
+     */
+    void setFrameworks(Iterable<String> frameworks)
+
+    /**
+     * Adds one or more frameworks to the list of restricted frameworks
+     * @param frameworks
+     */
+    void frameworks(String... frameworks)
+
+    /**
+     * Adds one or more frameworks to the list of restricted frameworks
+     * @param frameworks
+     */
+    void frameworks(Iterable<String> frameworks)
+
+    /**
+     * Adds a single framework to the list of restricted frameworks
+     * @param frameworks
+     */
+    void framework(String framework)
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyHandler.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyHandler.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies
+
+import org.gradle.api.tasks.Nested
+
+interface PaketDependencyHandler extends PaketDependencyConfigurationContainer, PaketDependencyMacros {
+
+    static final String MAIN_GROUP = "main"
+
+    /**
+     * Returns the {@code main} dependency configuration.
+     *
+     * This dependency configuration acts as the default group <b>Main</b>
+     * in the paket.dependencies file.
+     *
+     * @return the default {@code PaketDependencyConfiguration} object
+     */
+    PaketDependencyConfiguration getMain()
+
+    /**
+     * Executes the provided configuration closure on the @{code getMain} configuration
+     *
+     * @param depSpec a configuration closure executed on the main configuration
+     */
+    void main(Closure depSpec)
+
+    @Nested
+    PaketDependencyConfigurationContainer getConfigurationContainer()
+
+    boolean hasDependencies()
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyMacros.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyMacros.groovy
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Wooga GmbH
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@
  *
  */
 
-package wooga.gradle.paket.publish.repository
+package wooga.gradle.paket.base.dependencies
 
-interface NugetRepositoryHandlerConvention extends wooga.gradle.paket.base.repository.NugetRepositoryHandlerConvention<NugetArtifactRepository> {
+interface PaketDependencyMacros extends PaketDependencyFrameworkMacro {
 
 }

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyType.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/PaketDependencyType.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies
+
+/**
+ * Enum with all paket supported dependency types.
+ *
+ * @{see https://fsprojects.github.io/Paket/nuget-dependencies.html}
+ * @{see https://fsprojects.github.io/Paket/git-dependencies.html}
+ * @{see https://fsprojects.github.io/Paket/github-dependencies.html}
+ * @{see https://fsprojects.github.io/Paket/http-dependencies.html}
+ */
+enum PaketDependencyType {
+    nuget, clitool, github, git, gist, http
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultNugetDependency.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultNugetDependency.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies.internal
+
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.internal.artifacts.dependencies.AbstractDependency
+import wooga.gradle.paket.base.dependencies.NugetDependency
+import wooga.gradle.paket.base.dependencies.PaketDependencyType
+
+class DefaultNugetDependency extends AbstractDependency implements NugetDependency {
+
+    private String name
+    private String version
+
+    DefaultNugetDependency(final String name, final String version) {
+        this.name = name
+        this.version = version
+    }
+
+    @Override
+    String getGroup() {
+        return null
+    }
+
+    @Override
+    String getName() {
+        return name
+    }
+
+    @Override
+    String getVersion() {
+        return version
+    }
+
+    void setVersion(String version) {
+        this.version = version
+    }
+
+    DefaultNugetDependency version(String version) {
+        this.setVersion(version)
+        this
+    }
+
+    @Override
+    boolean contentEquals(Dependency dependency) {
+        (this.name == dependency.name && this.version == dependency.version)
+    }
+
+    @Override
+    Dependency copy() {
+        return new DefaultNugetDependency(name, version)
+    }
+
+    @Override
+    String toString() {
+        def s = [getType(), getName()]
+        if(getVersion()) {
+            s << getVersion()
+        }
+        return s.join(" ")
+    }
+
+    @Override
+    PaketDependencyType getType() {
+        return PaketDependencyType.nuget
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyConfiguration.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies.internal
+
+import org.gradle.api.Action
+import org.gradle.api.Named
+import org.gradle.api.internal.AbstractNamedDomainObjectContainer
+import org.gradle.internal.Actions
+import org.gradle.internal.reflect.DirectInstantiator
+import org.gradle.internal.reflect.Instantiator
+import org.gradle.util.ConfigureUtil
+import wooga.gradle.paket.base.dependencies.PaketDependency
+import wooga.gradle.paket.base.dependencies.PaketDependencyConfiguration
+import wooga.gradle.paket.base.dependencies.PaketDependencyType
+
+class DefaultPaketDependencyConfiguration extends AbstractNamedDomainObjectContainer<PaketDependency> implements PaketDependencyConfiguration, Named {
+
+    private final String name
+    private final PaketDependencyFactory dependencyFactory
+
+    DefaultPaketDependencyConfiguration(final String name, Instantiator instantiator = null) {
+        super(PaketDependency.class, instantiator ?: DirectInstantiator.INSTANCE)
+        this.name = name
+        this.dependencyFactory = instantiator.newInstance(PaketDependencyFactory, instantiator)
+    }
+
+    @Override
+    String getName() {
+        return name
+    }
+
+    @Override
+    boolean add(String dependencyNotation) {
+        add(dependencyNotation, Actions.doNothing())
+    }
+
+    @Override
+    boolean add(String dependencyNotation, Closure depSpec) {
+        add(dependencyNotation, ConfigureUtil.configureUsing(depSpec))
+    }
+
+    @Override
+    boolean add(String dependencyNotation, Action<PaketDependency> depSpec) {
+        create(dependencyNotation, depSpec)
+    }
+
+    @Override
+    boolean nuget(String dependencyNotation) {
+        nuget(dependencyNotation, Actions.doNothing())
+    }
+
+    @Override
+    boolean nuget(String dependencyNotation, Closure depSpec) {
+        nuget(dependencyNotation, ConfigureUtil.configureUsing(depSpec))
+    }
+
+    @Override
+    boolean nuget(String dependencyNotation, Action<PaketDependency> depSpec) {
+        add("${PaketDependencyType.nuget} ${dependencyNotation}", depSpec)
+    }
+
+    @Override
+    protected PaketDependency doCreate(String dependencyNotation) {
+        return dependencyFactory.create(dependencyNotation)
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyConfigurationContainer.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyConfigurationContainer.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies.internal
+
+import org.gradle.api.internal.AbstractNamedDomainObjectContainer
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
+import org.gradle.internal.reflect.Instantiator
+import wooga.gradle.paket.base.dependencies.PaketDependencyConfiguration
+import wooga.gradle.paket.base.dependencies.PaketDependencyConfigurationContainer
+
+class DefaultPaketDependencyConfigurationContainer extends AbstractNamedDomainObjectContainer<PaketDependencyConfiguration> implements PaketDependencyConfigurationContainer {
+
+    private final Instantiator instantiator
+
+    DefaultPaketDependencyConfigurationContainer(final Instantiator instantiator) {
+        super(PaketDependencyConfiguration.class, instantiator)
+        this.instantiator = instantiator
+    }
+
+    @Override
+    protected PaketDependencyConfiguration doCreate(String name) {
+        instantiator.newInstance(DefaultPaketDependencyConfiguration.class, name, instantiator)
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyHandler.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyHandler.groovy
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies.internal
+
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.internal.metaobject.DynamicInvokeResult
+import org.gradle.internal.metaobject.MethodAccess
+import org.gradle.internal.metaobject.MethodMixIn
+import org.gradle.internal.reflect.Instantiator
+import org.gradle.internal.service.ServiceRegistry
+import org.gradle.util.CollectionUtils
+import org.gradle.util.Configurable
+import org.gradle.util.ConfigureUtil
+import wooga.gradle.paket.base.dependencies.*
+
+class DefaultPaketDependencyHandler implements PaketDependencyHandler, MethodMixIn {
+
+    @Delegate(includeTypes = [PaketDependencyConfigurationHandler.class], interfaces = false)
+    private final DefaultPaketDependencyConfiguration mainConfiguration
+
+    @Delegate
+    private final PaketDependencyMacros macros
+
+    @Delegate(excludeTypes = [Configurable.class])
+    private final PaketDependencyConfigurationContainer configurationContainer
+    private final DynamicDependencyConfigurationMethods dynamicMethods
+    private final ServiceRegistry services
+    private final Instantiator instantiator
+
+    DefaultPaketDependencyHandler(final Project project) {
+        services = (project as ProjectInternal).getServices()
+        instantiator = services.get(Instantiator.class)
+        configurationContainer = instantiator.newInstance(DefaultPaketDependencyConfigurationContainer,instantiator)
+        mainConfiguration = configurationContainer.create(MAIN_GROUP)
+        macros = instantiator.newInstance(DefaultPaketDependencyMacros)
+        dynamicMethods = new DynamicDependencyConfigurationMethods()
+
+        addRule("valid group", { String name ->
+            if(NameUtil.validateName(name)) {
+                create(name)
+            }
+        })
+    }
+
+    @Override
+    boolean hasDependencies() {
+        configurationContainer.every { it.isEmpty() }
+    }
+
+    void clear() {
+        configurationContainer.each { it.clear() }
+    }
+
+    @Override
+    PaketDependencyConfiguration getMain() {
+        return mainConfiguration
+    }
+
+    NamedDomainObjectContainer<PaketDependencyConfiguration> configure(Closure configureClosure) {
+        return ConfigureUtil.configureSelf(configureClosure, this)
+    }
+
+    @Override
+    void main(@DelegatesTo(PaketDependencyConfiguration) Closure depSpec) {
+        this.mainConfiguration.configure(depSpec)
+    }
+
+    @Override
+    PaketDependencyConfigurationContainer getConfigurationContainer() {
+        return this.configurationContainer
+    }
+
+    @Override
+    MethodAccess getAdditionalMethods() {
+        return dynamicMethods
+    }
+
+    private class DynamicDependencyConfigurationMethods implements MethodAccess {
+        @Override
+        boolean hasMethod(String name, Object... arguments) {
+            List<?> normalizedArgs = CollectionUtils.flattenCollections(arguments)
+            return (normalizedArgs.size() == 1
+                        && normalizedArgs.get(0) instanceof Closure
+                        && configurationContainer.findByName(name.toLowerCase()) != null)
+        }
+
+        @Override
+        DynamicInvokeResult tryInvokeMethod(String name, Object... arguments) {
+            if(!NameUtil.validateName(name)) {
+                return DynamicInvokeResult.notFound()
+            }
+
+            PaketDependencyConfiguration configuration = configurationContainer.maybeCreate(name.toLowerCase())
+            List<?> normalizedArgs = CollectionUtils.flattenCollections(arguments)
+
+            if (normalizedArgs.size() == 1
+                    && normalizedArgs.get(0) instanceof Closure) {
+                return DynamicInvokeResult.found(configuration.configure((Closure) normalizedArgs.get(0)))
+            } else {
+                return DynamicInvokeResult.notFound()
+            }
+        }
+
+
+    }
+
+    private static class NameUtil {
+        static boolean validateName(String name) {
+            if(!Character.isJavaIdentifierStart(name.charAt(0))) {
+                return false
+            }
+
+            name.chars.every { Character.isJavaIdentifierPart(it) }
+        }
+    }
+}
+
+

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyMacros.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyMacros.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies.internal
+
+import org.gradle.util.GUtil
+import wooga.gradle.paket.base.dependencies.PaketDependencyMacros
+
+class DefaultPaketDependencyMacros implements PaketDependencyMacros {
+
+    private final Set<String> frameworks = new HashSet<String>()
+
+    @Override
+    List<String> getFrameworks() {
+        List<String> result = new ArrayList<String>()
+        for (String framework in this.frameworks) {
+            result.add(framework)
+        }
+        result
+    }
+
+    @Override
+    void setFrameworks(Iterable<String> frameworks) {
+        this.frameworks.clear()
+        GUtil.addToCollection(this.frameworks, frameworks)
+    }
+
+    @Override
+    void frameworks(String... frameworks) {
+        if (frameworks == null) {
+            throw new IllegalArgumentException("frameworks == null!")
+        }
+        this.frameworks.addAll(Arrays.asList(frameworks))
+    }
+
+    @Override
+    void frameworks(Iterable<String> frameworks) {
+        GUtil.addToCollection(this.frameworks, frameworks)
+    }
+
+    @Override
+    void framework(String framework) {
+        frameworks(framework)
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/PaketDependencyFactory.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/PaketDependencyFactory.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.dependencies.internal
+
+import org.gradle.internal.reflect.Instantiator
+import wooga.gradle.paket.base.dependencies.NugetDependency
+import wooga.gradle.paket.base.dependencies.PaketDependency
+import wooga.gradle.paket.base.dependencies.PaketDependencyFormatException
+import wooga.gradle.paket.base.dependencies.PaketDependencyType
+
+class PaketDependencyFactory {
+
+    private final Instantiator instantiator
+
+
+    PaketDependencyFactory(Instantiator instantiator) {
+        this.instantiator = instantiator
+    }
+
+    PaketDependency create(String dependencyNotation) {
+        def parts = dependencyNotation.split(' ', 2)
+        def type = parts[0]
+        def definition = parts[1]
+        PaketDependency dependency
+        switch (type as PaketDependencyType) {
+            case PaketDependencyType.nuget:
+                dependency = createNugetDependency(definition)
+                break
+            default:
+                throw new PaketDependencyFormatException("Unsupported dependencyNotation ${dependencyNotation}")
+        }
+
+        dependency
+    }
+
+    NugetDependency createNugetDependency(String dependencyNotation) {
+        def parts = dependencyNotation.split(' ', 2)
+        def name = parts[0]
+        def version = (parts.size() == 2) ? parts[1] : null
+        this.instantiator.newInstance(DefaultNugetDependency.class, name,version)
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/internal/DefaultPaketPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/internal/DefaultPaketPluginExtension.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.paket.base.internal
 
 import org.gradle.api.Project
 import wooga.gradle.paket.base.PaketPluginExtension
+import wooga.gradle.paket.base.dependencies.PaketDependencyHandler
 import wooga.gradle.paket.base.utils.internal.PaketDependencies
 
 class DefaultPaketPluginExtension implements PaketPluginExtension {
@@ -34,6 +35,8 @@ class DefaultPaketPluginExtension implements PaketPluginExtension {
     private static final String DEFAULT_MONO_EXECUTABLE = "mono"
     private static final String DEFAULT_PAKET_LOCK_FILE_NAME = "paket.lock"
 
+    private final PaketDependencyHandler dependencyHandler
+
     protected Project project
     protected File customPaketDirectory
     protected File customMonoExecutable
@@ -42,8 +45,9 @@ class DefaultPaketPluginExtension implements PaketPluginExtension {
     protected String customVersion
     protected String customPaketBootstrapperUrl
 
-    DefaultPaketPluginExtension(final Project project) {
+    DefaultPaketPluginExtension(final Project project, final PaketDependencyHandler dependencyHandler) {
         this.project = project
+        this.dependencyHandler = dependencyHandler
     }
 
     @Override
@@ -172,5 +176,10 @@ class DefaultPaketPluginExtension implements PaketPluginExtension {
     @Override
     File getPaketLockFile() {
         return new File(project.projectDir, DEFAULT_PAKET_LOCK_FILE_NAME)
+    }
+
+    @Override
+    PaketDependencyHandler getDependencyHandler() {
+        dependencyHandler
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/base/repository/NugetArtifactRepository.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/repository/NugetArtifactRepository.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.repository
+
+import org.gradle.api.artifacts.repositories.ArtifactRepository
+import org.gradle.api.artifacts.repositories.AuthenticationSupported
+import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+
+interface NugetArtifactRepository extends ArtifactRepository, AuthenticationSupported, FlatDirectoryArtifactRepository {
+
+    @Input
+    String getName()
+
+    @Input
+    URI getUrl()
+
+    @Input
+    Set<File> getDirs()
+
+    void setUrl(URI var1)
+
+    void setUrl(Object var1)
+}

--- a/src/main/groovy/wooga/gradle/paket/base/repository/NugetRepositoryHandlerConvention.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/repository/NugetRepositoryHandlerConvention.groovy
@@ -15,8 +15,15 @@
  *
  */
 
-package wooga.gradle.paket.publish.repository
+package wooga.gradle.paket.base.repository
 
-interface NugetRepositoryHandlerConvention extends wooga.gradle.paket.base.repository.NugetRepositoryHandlerConvention<NugetArtifactRepository> {
+import org.gradle.api.Action
+import org.gradle.api.artifacts.repositories.ArtifactRepository
 
+interface NugetRepositoryHandlerConvention<T extends ArtifactRepository> {
+    static final String NUGET_REPO_DEFAULT_NAME = "nuget"
+
+    T nuget()
+    T nuget(Action<? super T> action)
+    T nuget(Closure configureClosure)
 }

--- a/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepository.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepository.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.repository.internal
+
+import com.google.common.collect.Lists
+import groovy.transform.EqualsAndHashCode
+import org.gradle.api.artifacts.repositories.AuthenticationContainer
+import org.gradle.api.internal.artifacts.repositories.AbstractArtifactRepository
+import org.gradle.api.internal.artifacts.repositories.AuthenticationSupporter
+import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.internal.reflect.Instantiator
+import wooga.gradle.paket.base.repository.NugetArtifactRepository
+
+@EqualsAndHashCode(includeFields=true)
+class DefaultNugetArtifactRepository extends AbstractArtifactRepository implements NugetArtifactRepository {
+
+    private final FileResolver fileResolver
+    private Object url
+    private List<Object> dirs = new ArrayList<Object>()
+
+    @Delegate
+    private final AuthenticationSupporter delegate
+
+    DefaultNugetArtifactRepository(FileResolver fileResolver,
+                                   Instantiator instantiator,
+                                   AuthenticationContainer authenticationContainer) {
+        this.delegate = new AuthenticationSupporter(instantiator, authenticationContainer)
+        this.fileResolver = fileResolver
+    }
+
+    @Input
+    @Override
+    URI getUrl() {
+        return url == null ? null : fileResolver.resolveUri(url)
+    }
+
+    @Override
+    void setUrl(URI url) {
+        this.url = url
+    }
+
+    @Override
+    void setUrl(Object url) {
+        this.url = url
+    }
+
+    @Input
+    @Override
+    Set<File> getDirs() {
+        return fileResolver.resolveFiles(dirs).getFiles()
+    }
+
+    @Override
+    void setDirs(Set<File> dirs) {
+        assertURL()
+        setDirs((Iterable<?>) dirs)
+    }
+
+    @Override
+    void setDirs(Iterable<?> dirs) {
+        assertURL()
+        this.dirs = Lists.newArrayList(dirs)
+    }
+
+    @Override
+    void dir(Object dir) {
+        assertURL()
+        dirs(dir)
+    }
+
+    @Override
+    void dirs(Object... dirs) {
+        assertURL()
+        this.dirs.addAll(Arrays.asList(dirs))
+    }
+
+    private assertURL() {
+        if(url != null)
+        {
+            throw new Exception("url already set")
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepositoryHandlerConvention.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepositoryHandlerConvention.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.repository.internal
+
+import org.gradle.api.Action
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.AuthenticationContainer
+import org.gradle.api.internal.artifacts.DefaultArtifactRepositoryContainer
+import org.gradle.api.internal.file.FileResolver
+import org.gradle.authentication.http.BasicAuthentication
+import org.gradle.internal.authentication.DefaultAuthenticationContainer
+import org.gradle.internal.authentication.DefaultBasicAuthentication
+import org.gradle.internal.reflect.Instantiator
+import org.gradle.util.ConfigureUtil
+import wooga.gradle.paket.base.repository.NugetRepositoryHandlerConvention
+import wooga.gradle.paket.base.repository.NugetArtifactRepository
+
+class DefaultNugetArtifactRepositoryHandlerConvention implements NugetRepositoryHandlerConvention<NugetArtifactRepository> {
+
+    private final DefaultArtifactRepositoryContainer handler
+    private final Instantiator instantiator
+    private final FileResolver fileResolver
+
+    DefaultNugetArtifactRepositoryHandlerConvention(RepositoryHandler handler, FileResolver fileResolver, Instantiator instantiator) {
+        this.handler = handler
+        this.instantiator = instantiator
+        this.fileResolver = fileResolver
+    }
+
+    @Override
+    NugetArtifactRepository nuget() {
+        handler.addRepository(createNugetRepository(), NUGET_REPO_DEFAULT_NAME)
+    }
+
+    @Override
+    NugetArtifactRepository nuget(Action<? super NugetArtifactRepository> action) {
+        handler.addRepository(createNugetRepository(), NUGET_REPO_DEFAULT_NAME, action)
+    }
+
+    @Override
+    NugetArtifactRepository nuget(Closure configureClosure) {
+        return nuget(ConfigureUtil.configureUsing(configureClosure))
+    }
+
+    protected NugetArtifactRepository createNugetRepository() {
+        instantiator.newInstance(DefaultNugetArtifactRepository.class, fileResolver, instantiator, createAuthenticationContainer())
+    }
+
+    protected AuthenticationContainer createAuthenticationContainer() {
+        DefaultAuthenticationContainer container = instantiator.newInstance(DefaultAuthenticationContainer.class, instantiator)
+
+        container.registerBinding(BasicAuthentication.class, DefaultBasicAuthentication.class)
+        return container
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/tasks/PaketDependenciesTask.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/PaketDependenciesTask.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.base.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Task
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import wooga.gradle.paket.base.PaketBasePlugin
+import wooga.gradle.paket.base.PaketPluginExtension
+import wooga.gradle.paket.base.dependencies.PaketDependencyConfiguration
+import wooga.gradle.paket.base.dependencies.PaketDependencyConfigurationContainer
+import wooga.gradle.paket.base.dependencies.PaketDependencyHandler
+import wooga.gradle.paket.base.dependencies.PaketDependencyMacros
+import wooga.gradle.paket.base.repository.NugetArtifactRepository
+
+import java.nio.file.Path
+
+class PaketDependenciesTask extends DefaultTask {
+
+    protected final PaketDependencyConfigurationContainer configurationContainer
+    protected final PaketDependencyMacros macros
+    protected final PaketDependencyHandler dependencyHandler
+
+    private Object output
+
+    @OutputFile
+    File getOutput() {
+        project.file(output)
+    }
+
+    void setOutput(Object value) {
+        this.output = path
+    }
+
+    PaketDependenciesTask output(Object path) {
+        this.output = path
+        this
+    }
+
+    @Nested
+    private PaketDependencyMacros getMacros() {
+        macros
+    }
+
+    @Nested
+    private PaketDependencyConfigurationContainer getDependencyConfigurationContainer() {
+        dependencyHandler.configurationContainer
+    }
+
+    @Nested
+    private List<NugetArtifactRepository> getRepositories() {
+        project.repositories.findAll {it instanceof NugetArtifactRepository} as List<NugetArtifactRepository>
+    }
+
+    private String content
+
+    /**
+     *
+     * @return
+     */
+    @Optional
+    @Input
+    private String getContent() {
+        def v = project.gradle.gradleVersion.split(/\./).collect {Integer.parseInt(it)}
+        if((v[0] == 4 && v[1] >= 7) || v[0] > 4) {
+            content = null
+        }
+        else {
+            if(!content) {
+                def w = new StringWriter()
+                writeDependencies(w)
+                content = w.toString()
+            }
+        }
+        content
+    }
+
+    PaketDependenciesTask() {
+        super()
+        def extension = project.extensions.getByName(PaketBasePlugin.EXTENSION_NAME) as PaketPluginExtension
+        dependencyHandler = extension.dependencyHandler
+        configurationContainer = extension.dependencyHandler
+        macros = extension.dependencyHandler
+
+        output = extension.paketDependenciesFile
+        onlyIf(new Spec<Task>() {
+            @Override
+            boolean isSatisfiedBy(Task element) {
+                return !dependencyHandler.hasDependencies()
+            }
+        })
+    }
+
+    @TaskAction
+    protected void generate() {
+        writeDependenciesTo(getOutput())
+    }
+
+    protected void writeDependenciesTo(File dependencies) {
+        dependencies.withWriter { Writer w -> writeDependencies(w) }
+    }
+
+    protected void writeDependencies(Writer w) {
+        writeMacros(w)
+        writeSources(w)
+        writeGroups(w)
+    }
+
+    protected static void writeGroup(PaketDependencyConfiguration group, Writer writer, boolean printGroupStatement = true, String indent = '    ') {
+        if(printGroupStatement) {
+            writer.println()
+            writer.println("group ${group.getName().capitalize()}")
+        }
+
+        group.all { dependency ->
+            writer.println("${indent}${dependency.toString()}")
+        }
+    }
+
+    protected void writeGroups(Writer writer) {
+        def main = configurationContainer.getByName(PaketDependencyHandler.MAIN_GROUP)
+        writeGroup(main, writer, false,'')
+
+        configurationContainer.findAll {it.name != 'main'}.each {
+            writeGroup(it, writer)
+        }
+    }
+
+    protected void writeSources(Writer writer) {
+        getRepositories().each { repo ->
+            if(repo.url) {
+                writer.print("source ${repo.url}")
+                def credentials = repo.getCredentials()
+                if(credentials.username && credentials.password) {
+                    writer.println(" username: \"${credentials.username}\" password: \"${credentials.password}\"")
+                }
+                else{
+                    writer.println()
+                }
+            } else {
+                repo.dirs.each { dir ->
+                    Path pathAbsolute = dir.toPath()
+                    Path pathBase = getOutput().parentFile.toPath()
+                    Path pathRelative = pathBase.relativize(pathAbsolute)
+
+                    writer.println("source ${pathRelative.toString()}")
+                }
+            }
+        }
+    }
+
+    protected void writeMacros(Writer writer) {
+        def frameworks = getMacros().frameworks
+        if(frameworks) {
+            writer.println("framework: ${frameworks.join(", ")}")
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/utils/PaketDependencies.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/utils/PaketDependencies.groovy
@@ -24,4 +24,5 @@ interface PaketDependencies {
      * @return list of .NET frameworks configured
      */
     List<String> getFrameworks()
+
 }

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -69,8 +69,8 @@ class PaketPackPlugin implements Plugin<Project> {
 
         project.pluginManager.apply(BasePlugin.class)
         project.pluginManager.apply(PaketBasePlugin.class)
-
-        final extension = project.extensions.create(EXTENSION_NAME, DefaultPaketPackPluginExtension, project)
+        final PaketPluginExtension baseExtension = project.extensions.getByName(PaketBasePlugin.EXTENSION_NAME) as PaketPluginExtension
+        final extension = project.extensions.create(EXTENSION_NAME, DefaultPaketPackPluginExtension, project, baseExtension.dependencyHandler)
 
         final configuration = project.configurations.getByName(PaketBasePlugin.PAKET_CONFIGURATION)
         final templateFiles = project.fileTree(project.projectDir)

--- a/src/main/groovy/wooga/gradle/paket/pack/internal/DefaultPaketPackPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/internal/DefaultPaketPackPluginExtension.groovy
@@ -1,11 +1,12 @@
 package wooga.gradle.paket.pack.internal
 
 import org.gradle.api.Project
+import wooga.gradle.paket.base.dependencies.PaketDependencyHandler
 import wooga.gradle.paket.base.internal.DefaultPaketPluginExtension
 
 class DefaultPaketPackPluginExtension extends DefaultPaketPluginExtension {
-    DefaultPaketPackPluginExtension(Project project) {
-        super(project)
+    DefaultPaketPackPluginExtension(Project project, final PaketDependencyHandler dependencyHandler) {
+        super(project, dependencyHandler)
     }
 
     @Override

--- a/src/main/groovy/wooga/gradle/paket/publish/PaketPublishPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/PaketPublishPlugin.groovy
@@ -34,8 +34,8 @@ import wooga.gradle.paket.base.PaketBasePlugin
 import wooga.gradle.paket.publish.internal.DefaultPaketPushPluginExtension
 import wooga.gradle.paket.publish.repository.internal.DefaultNugetRepositoryHandlerConvention
 import wooga.gradle.paket.publish.repository.internal.NugetRepository
-import wooga.gradle.paket.publish.tasks.internal.PaketCopy
 import wooga.gradle.paket.publish.tasks.PaketPush
+import wooga.gradle.paket.publish.tasks.internal.PaketCopy
 
 /**
  * A {@link Plugin} which adds tasks to publish nuget files with {@code paket}.

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.paket.unity
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import wooga.gradle.paket.base.PaketBasePlugin
+import wooga.gradle.paket.base.PaketPluginExtension
 import wooga.gradle.paket.get.PaketGetPlugin
 import wooga.gradle.paket.get.tasks.PaketUpdate
 import wooga.gradle.paket.unity.internal.DefaultPaketUnityPluginExtension
@@ -50,8 +51,9 @@ class PaketUnityPlugin implements Plugin<Project> {
         this.project = project
 
         project.pluginManager.apply(PaketBasePlugin.class)
+        final PaketPluginExtension baseExtension = project.extensions.getByName(PaketBasePlugin.EXTENSION_NAME) as PaketPluginExtension
 
-        final extension = project.extensions.create(EXTENSION_NAME, DefaultPaketUnityPluginExtension, project)
+        final extension = project.extensions.create(EXTENSION_NAME, DefaultPaketUnityPluginExtension, project, baseExtension.dependencyHandler)
         createPaketUnityInstallTasks(project, extension)
 
         project.tasks.matching({ it.name.startsWith("paketUnity") }).each { task ->

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.paket.unity.internal
 
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
+import wooga.gradle.paket.base.dependencies.PaketDependencyHandler
 import wooga.gradle.paket.base.internal.DefaultPaketPluginExtension
 import wooga.gradle.paket.unity.PaketUnityPluginExtension
 
@@ -29,8 +30,8 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
     protected String customPaketOutputDirectory
 
-    DefaultPaketUnityPluginExtension(Project project) {
-        super(project)
+    DefaultPaketUnityPluginExtension(Project project,final PaketDependencyHandler dependencyHandler) {
+        super(project, dependencyHandler)
     }
 
     @Override

--- a/src/test/groovy/wooga/gradle/paket/base/repository/NugetRepositorySpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/base/repository/NugetRepositorySpec.groovy
@@ -1,0 +1,39 @@
+package wooga.gradle.paket.base.repository
+
+import spock.lang.Specification
+import wooga.gradle.paket.base.repository.internal.NugetRepository
+import wooga.gradle.paket.publish.repository.internal.NugetRepository
+
+class NugetRepositorySpec extends Specification {
+
+    def "applies properties"(){
+
+        given: "a fresh NugetRepository object"
+        def vo = new NugetRepository()
+
+        when: "set properties via methods"
+        vo.url("url")
+        vo.name("name")
+        vo.apiKey("apiKey")
+        vo.endpoint("endpoint")
+
+        then:
+        vo.url == "url"
+        vo.name == "name"
+        vo.apiKey == "apiKey"
+        vo.endpoint == "endpoint"
+    }
+
+    def "applies all properties"(){
+
+        given: "a fresh NugetRepository object"
+        def vo = new NugetRepository()
+
+        when: "set path and url"
+        vo.url("url")
+        vo.path("path")
+
+        then: "Exception gets thrown"
+        thrown(Exception)
+    }
+}


### PR DESCRIPTION
## Description

This is the first part if bringing the basic paket configuration
(paket.dependencies, paket.template, paket.references) into the gradle
project. This change adds custom `paket` dependency handler to the
gradle dependency handler and a nuget repository factory.

*build.gradle*
```groovy
dependencies {
    paket {
        nuget "Test ~> 1"
    }
}

repositories {
   nuget {
       url 'some/url'
   }
}
```

At the moment only `nuget` dependencies are supported.
When dependencies are configured in the `build.gradle` file, a
`paket.dependencies` file will be generated. If this file already
exists, it will be overridden.

## Changes

![ADD] paket dependencies handler
![ADD] nuget dependency definition
![ADD] nuget dependency source artifact repository handler
![ADD] new task `paketDependencies`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
