### PR TITLE
Refactor integration spec for paket unity change specs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,5 +10,5 @@ withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', var
                             "nugetkey=${artifactory_deploy}"
                           ]
 
-    buildGradlePlugin plaforms: ['osx','windows'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
+    buildGradlePlugin plaforms: ['osx','win'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
 }

--- a/src/integrationTest/groovy/wooga/gradle/extensions/GradleIntegrationSpecInterceptor.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/extensions/GradleIntegrationSpecInterceptor.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.extensions
+
+import nebula.test.IntegrationSpec
+import org.spockframework.runtime.extension.AbstractMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.SpecInfo
+
+abstract class GradleIntegrationSpecInterceptor extends AbstractMethodInterceptor {
+
+    protected final String fieldName
+    protected IntegrationSpec spec
+    File projectDir
+
+    GradleIntegrationSpecInterceptor(String fieldName) {
+        this.fieldName = fieldName
+    }
+
+    protected final IntegrationSpec getSpecification(IMethodInvocation invocation) {
+        invocation.instance ?: invocation.sharedInstance
+    }
+
+    @Override
+    void interceptSetupMethod(IMethodInvocation invocation) throws Throwable {
+        invocation.proceed()
+
+        if (!spec) {
+            initProject(invocation)
+        } else {
+            setupProject(invocation)
+        }
+    }
+
+    @Override
+    void interceptCleanupMethod(IMethodInvocation invocation) throws Throwable {
+        invocation.proceed()
+
+        if (spec) {
+            spec = null
+        }
+    }
+
+    abstract void setupProject(IMethodInvocation invocation)
+
+    final void initProject(IMethodInvocation invocation) {
+        final IntegrationSpec specInstance = getSpecification(invocation)
+        spec = specInstance
+        projectDir = specInstance.projectDir
+
+        specInstance."$fieldName" = this
+        assert specInstance."$fieldName" == this
+    }
+
+    void install(SpecInfo spec) {
+        spec.addSetupInterceptor(this)
+        spec.addCleanupInterceptor(this)
+    }
+
+    //Todo think about moving this
+
+    protected File directory(String path, File baseDir = getProjectDir()) {
+        new File(baseDir, path).with {
+            mkdirs()
+            it
+        }
+    }
+
+    protected File file(String path, File baseDir = getProjectDir()) {
+        def splitted = path.split('/')
+        def directory = splitted.size() > 1 ? directory(splitted[0..-2].join('/'), baseDir) : baseDir
+        def file = new File(directory, splitted[-1])
+        file.createNewFile()
+        file
+    }
+
+    protected File createFile(String path, File baseDir = getProjectDir()) {
+        File file = file(path, baseDir)
+        if (!file.exists()) {
+            assert file.parentFile.mkdirs() || file.parentFile.exists()
+            file.createNewFile()
+        }
+        file
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/extensions/PaketDependencySetupExtension.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/extensions/PaketDependencySetupExtension.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.extensions
+
+import groovy.transform.InheritConstructors
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FieldInfo
+
+class PaketDependencySetupExtension extends AbstractAnnotationDrivenExtension<PaketDependency> {
+
+    @Override
+    void visitFieldAnnotation(PaketDependency annotation, FieldInfo field) {
+        def interceptor
+        interceptor = new PaketDependencyInterceptor(field.name, annotation.projectDependencies())
+        interceptor.install(field.parent.getTopSpec())
+        interceptor.install(field.parent.getBottomSpec())
+    }
+}
+
+@InheritConstructors
+class PaketDependencyInterceptor extends GradleIntegrationSpecInterceptor implements PaketDependencySetup {
+
+    List<String> projectDependencies
+
+    protected File paketDependencies
+    protected File paketLock
+
+    PaketDependencyInterceptor(String fieldName, String[] projectDependencies) {
+        super(fieldName)
+        this.projectDependencies = projectDependencies.toList()
+    }
+
+    @Override
+    File getPaketDependencies() {
+        paketDependencies
+    }
+
+    @Override
+    File getPaketLock() {
+        paketLock
+    }
+
+    void setupProject(IMethodInvocation invocation) {
+        createDependencies()
+    }
+
+    File createDependencies() {
+        def dependenciesFile = createFile("paket.dependencies")
+        dependenciesFile.text = ""
+        dependenciesFile << """source https://nuget.org/api/v2
+nuget ${projectDependencies.join("\nnuget ")}""".stripIndent()
+
+        projectDependencies.each { dependency ->
+            createFile("packages/${dependency}/content/ContentFile.cs")
+        }
+        createLockFile(projectDependencies)
+        paketDependencies = dependenciesFile
+        dependenciesFile
+    }
+
+    File createDependencies(List<String> dependencies) {
+        projectDependencies = dependencies
+        createDependencies()
+    }
+
+    void createLockFile(List<String> dependencies) {
+        def lockFile = createFile("paket.lock")
+        lockFile.text = ""
+        lockFile << """
+NUGET
+    remote: https://wooga.artifactoryonline.com/wooga/api/nuget/atlas-nuget
+        ${dependencies.join("\n")}""".stripIndent()
+        paketLock = lockFile
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/extensions/PaketUnitySetup.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/extensions/PaketUnitySetup.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.extensions
+
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@ExtensionAnnotation(PaketUnitySetupExtension)
+@interface PaketUnity {
+    String projectName() default ""
+    String[] projectReferences() default []
+}
+
+interface PaketUnitySetup {
+    File getProjectReferencesFile()
+    File getInstallDirectory()
+    File getUnityProjectDir()
+    String getName()
+
+    List<String> getProjectReferences()
+
+    File createOrUpdateReferenceFile()
+    File createOrUpdateReferenceFile(List<String> projectReferences)
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@ExtensionAnnotation(PaketDependencySetupExtension)
+@interface PaketDependency {
+    String[] projectDependencies() default []
+}
+
+interface PaketDependencySetup {
+    File getPaketDependencies()
+    File getPaketLock()
+
+    List<String> getProjectDependencies()
+
+    File createDependencies()
+    File createDependencies(List<String> dependencies)
+}

--- a/src/integrationTest/groovy/wooga/gradle/extensions/PaketUnitySetupExtension.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/extensions/PaketUnitySetupExtension.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.extensions
+
+import groovy.transform.InheritConstructors
+import nebula.test.IntegrationSpec
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.AbstractMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FieldInfo
+import org.spockframework.runtime.model.SpecInfo
+import wooga.gradle.paket.base.internal.DefaultPaketPluginExtension
+import wooga.gradle.paket.unity.internal.DefaultPaketUnityPluginExtension
+
+class PaketUnitySetupExtension extends AbstractAnnotationDrivenExtension<PaketUnity> {
+    @Override
+    void visitFieldAnnotation(PaketUnity annotation, FieldInfo field) {
+        def interceptor
+        interceptor = new PaketUnitySetupInterceptor(field.name, annotation.projectName(), annotation.projectReferences())
+        interceptor.install(field.parent.getTopSpec())
+        interceptor.install(field.parent.getBottomSpec())
+    }
+}
+
+@InheritConstructors
+class PaketUnitySetupInterceptor extends GradleIntegrationSpecInterceptor implements PaketUnitySetup {
+
+    protected final String projectName
+
+    File projectReferencesFile
+
+    List<String> projectReferences
+
+    @Override
+    String getName() {
+        return projectName
+    }
+
+    PaketUnitySetupInterceptor(String fieldName, String projectName, String[] projectReferences) {
+        super(fieldName)
+        this.projectName = projectName ?: fieldName
+        this.projectReferences = projectReferences.toList()
+    }
+
+    void setupProject(IMethodInvocation invocation) {
+        createOrUpdateReferenceFile()
+    }
+
+    @Override
+    File getInstallDirectory() {
+        new File(unityProjectDir, "/Assets/${DefaultPaketUnityPluginExtension.DEFAULT_PAKET_DIRECTORY}")
+    }
+
+    @Override
+    File getUnityProjectDir() {
+        new File(projectDir, projectName)
+    }
+
+    File createOrUpdateReferenceFile() {
+        def path = "${projectName}/${DefaultPaketUnityPluginExtension.DEFAULT_PAKET_UNITY_REFERENCES_FILE_NAME}"
+        def referencesFile = createFile(path)
+        referencesFile.text = """${projectReferences.join("\r")}""".stripIndent()
+        this.projectReferencesFile = referencesFile
+        referencesFile
+    }
+
+    File createOrUpdateReferenceFile(List<String> projectReferences) {
+        this.projectReferences = projectReferences
+        createOrUpdateReferenceFile()
+    }
+}


### PR DESCRIPTION
## Description

This patch moves some boilerplate setup code into custom spock
extensions. This patch adds two extensions that provide a clean
interface for testing paket and paket unity project integrations:

* @PaketDependency
* @PaketUnity

### @PaketDependency

Is a resource extension which setups a paket project.
It will create a `paket.dependendies` along with a `paket.lock` file and
stub `cs` files in `packages` directory. This extensions should be
updated for future use in other tests (don't create a lock file,
specify sources, etc).

```java
@ExtensionAnnotation(PaketDependencySetupExtension)
@interface PaketDependency {
    String[] projectDependencies() default []
}
```

```groovy
class ASpec extends IntegrationSpec {
    @PaketDependency(projectDependencies = ["D1", "D2", "D3"])
    PaketDependencySetup paketSetup
```

The annotated field will turn into a an Object of `PaketDependencySetup`
It is possible to override and regenerate the dependencies during test runtime.

```groovy
interface PaketDependencySetup {
    File getPaketDependencies()
    File getPaketLock()

    List<String> getProjectDependencies()

    File createDependencies()
    File createDependencies(List<String> dependencies)
}
```

### @PaketUnity

The paket unity extension creates a mock setup for unity. Each field
annotated with `@PaketUnity` will generate a mock unity project.

```java
@ExtensionAnnotation(PaketUnitySetupExtension)
@interface PaketUnity {
    String projectName() default ""
    String[] projectReferences() default []
}
```

```groovy
class ASpec extends IntegrationSpec {
    @PaketUnity(projectReferences = ["D1", "D2", "D3"])
    PaketUnitySetup unityProject1
```

The annotated field will turn into a an Object of `PaketUnitySetup`
It is possible to override and regenerate the references during test runtime.

```groovy
interface PaketUnitySetup {
    File getProjectReferencesFile()
    File getInstallDirectory()
    File getUnityProjectDir()
    String getName()

    List<String> getProjectReferences()

    File createOrUpdateReferenceFile()
    File createOrUpdateReferenceFile(List<String> projectReferences)
}
```

## Changes

![ADD] `@PaketDependency` spock test extension
![ADD] `@PaketUnity` spock test extension
![IMPROVE] integration specs

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
