### PR TITLE
Add assembly definition strategies

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityAssemblyDefinitionStrategySpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityAssemblyDefinitionStrategySpec.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.unity
+
+import nebula.test.IntegrationSpec
+import spock.lang.Unroll
+import wooga.gradle.extensions.PaketDependency
+import wooga.gradle.extensions.PaketDependencySetup
+import wooga.gradle.extensions.PaketUnity
+import wooga.gradle.extensions.PaketUnitySetup
+import wooga.gradle.paket.get.PaketGetPlugin
+
+class PaketUnityAssemblyDefinitionStrategySpec extends IntegrationSpec {
+
+    @PaketDependency
+    PaketDependencySetup _paketSetup
+
+    @PaketUnity
+    PaketUnitySetup unityProject
+
+    def setup() {
+        buildFile << """
+        ${applyPlugin(PaketGetPlugin)}
+        ${applyPlugin(PaketUnityPlugin)}
+        """.stripIndent()
+    }
+
+    @Unroll
+    def "task :paketInstall #message in #location paket install directory when assembly definition strategy is set to #strategy"() {
+        given:
+        buildFile << """
+        paketUnity.assemblyDefinitionFileStrategy = "$strategy"
+        """.stripIndent()
+
+        and: "a file matching the file pattern"
+        def baseDir = (location == "root") ? unityProject.installDirectory : new File(unityProject.installDirectory, "some/nested/directory")
+        baseDir.mkdirs()
+
+        def fileToKeep = createFile("test${filePattern}", baseDir) << "random content"
+
+        when:
+        runTasksSuccessfully(PaketUnityPlugin.INSTALL_TASK_NAME)
+
+        then:
+        fileToKeep.exists() == expectFileToExist
+
+        where:
+        filePattern    | location | strategy   | expectFileToExist
+        ".asmdef"      | "root"   | "manual"   | true
+        ".asmdef"      | "nested" | "manual"   | true
+        ".asmdef.meta" | "root"   | "manual"   | true
+        ".asmdef.meta" | "nested" | "manual"   | true
+        ".asmdef"      | "root"   | "disabled" | false
+        ".asmdef"      | "nested" | "disabled" | false
+        ".asmdef.meta" | "root"   | "disabled" | false
+        ".asmdef.meta" | "nested" | "disabled" | false
+        message = (expectFileToExist) ? "keeps files with $filePattern" : "cleans assembly definition files"
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -23,6 +23,7 @@ import wooga.gradle.paket.base.PaketBasePlugin
 import wooga.gradle.paket.base.PaketPluginExtension
 import wooga.gradle.paket.get.PaketGetPlugin
 import wooga.gradle.paket.get.tasks.PaketUpdate
+import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
 import wooga.gradle.paket.unity.internal.DefaultPaketUnityPluginExtension
 import wooga.gradle.paket.unity.tasks.PaketUnityInstall
 
@@ -55,6 +56,7 @@ class PaketUnityPlugin implements Plugin<Project> {
 
         final extension = project.extensions.create(EXTENSION_NAME, DefaultPaketUnityPluginExtension, project, baseExtension.dependencyHandler)
         createPaketUnityInstallTasks(project, extension)
+        extension.assemblyDefinitionFileStrategy = AssemblyDefinitionFileStrategy.manual
 
         project.tasks.matching({ it.name.startsWith("paketUnity") }).each { task ->
             task.onlyIf {
@@ -81,6 +83,7 @@ class PaketUnityPlugin implements Plugin<Project> {
                 group = GROUP
                 description = "Installs dependencies for Unity3d project ${referenceFile.parentFile.name} "
                 conventionMapping.map("paketOutputDirectoryName", { extension.getPaketOutputDirectoryName() })
+                conventionMapping.map("assemblyDefinitionFileStrategy", { extension.getAssemblyDefinitionFileStrategy() })
                 frameworks = extension.getPaketDependencies().getFrameworks()
                 lockFile = extension.getPaketLockFile()
                 referencesFile = referenceFile

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
@@ -19,9 +19,10 @@ package wooga.gradle.paket.unity
 
 import org.gradle.api.file.FileCollection
 import wooga.gradle.paket.base.PaketPluginExtension
+import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
 
 /**
- * A extension point for paket unity
+ * A extensions point for paket unity
  */
 interface PaketUnityPluginExtension extends PaketPluginExtension {
 
@@ -42,4 +43,16 @@ interface PaketUnityPluginExtension extends PaketPluginExtension {
      * @param directory name of the output directory
      */
     void setPaketOutputDirectoryName(String directory)
+
+    /**
+     * @return the assembly definition file strategy
+     */
+    AssemblyDefinitionFileStrategy getAssemblyDefinitionFileStrategy()
+
+    /**
+     * Sets the assembly definition strategy to be used during install.
+     *
+     * @param strategy the strategy to be used
+     */
+    void setAssemblyDefinitionFileStrategy(AssemblyDefinitionFileStrategy strategy)
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/AssemblyDefinitionFileStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/AssemblyDefinitionFileStrategy.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.paket.unity.internal
+
+enum AssemblyDefinitionFileStrategy {
+    manual, disabled
+}

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -28,10 +28,12 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
     public static final String DEFAULT_PAKET_UNITY_REFERENCES_FILE_NAME = "paket.unity3d.references"
     public static final String DEFAULT_PAKET_DIRECTORY = "Paket.Unity3D"
 
+    protected AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
     protected String customPaketOutputDirectory
 
     DefaultPaketUnityPluginExtension(Project project,final PaketDependencyHandler dependencyHandler) {
         super(project, dependencyHandler)
+        assemblyDefinitionFileStrategy
     }
 
     @Override
@@ -47,5 +49,15 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
     void setPaketOutputDirectoryName(String directory) {
         customPaketOutputDirectory = directory
+    }
+
+    @Override
+    AssemblyDefinitionFileStrategy getAssemblyDefinitionFileStrategy() {
+        return assemblyDefinitionFileStrategy
+    }
+
+    @Override
+    void setAssemblyDefinitionFileStrategy(AssemblyDefinitionFileStrategy strategy) {
+        assemblyDefinitionFileStrategy = strategy
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -20,7 +20,6 @@ package wooga.gradle.paket.unity.tasks
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Action
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.FileTreeElement
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.ConventionTask
@@ -33,6 +32,7 @@ import org.gradle.api.tasks.incremental.InputFileDetails
 import wooga.gradle.paket.base.utils.internal.PaketLock
 import wooga.gradle.paket.base.utils.internal.PaketUnityReferences
 import wooga.gradle.paket.unity.PaketUnityPlugin
+import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
 
 /**
  * A task to copy referenced NuGet packages into Unity3D projects.
@@ -76,6 +76,9 @@ class PaketUnityInstall extends ConventionTask {
      */
     @Input
     String paketOutputDirectoryName
+
+    @Input
+    AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
 
     File projectRoot
 
@@ -170,9 +173,11 @@ class PaketUnityInstall extends ConventionTask {
     }
 
     protected void cleanOutputDirectory() {
-        def tree = project.fileTree(getOutputDirectory()) {
-            exclude("**/*.asmdef")
-            exclude("**/*.asmdef.meta")
+        def tree = project.fileTree(getOutputDirectory())
+
+        if(getAssemblyDefinitionFileStrategy() == AssemblyDefinitionFileStrategy.manual) {
+            tree.exclude("**/*.asmdef")
+            tree.exclude("**/*.asmdef.meta")
         }
 
         logger.info("delete files in directory: ${getOutputDirectory()}")


### PR DESCRIPTION
## Description

This patch adds a configuration to the paket-unity extensions to configure handling of assembly definition files. In this first patch only two options are supported:

* `manual` - all `.asmdef` and `.asmdef.meta` files will be preserved (default)
* `disabled` - the old behavior of cleaning all files before install

example:

*build.gradle*

```groovy
paketUnity {
    assemblyDefinitionFileStrategy = "manual"
}
```

## Changes

* ![ADD] new configuration option `assemblyDefinitionFileStrategy`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
