### PR TITLE
Fix dependency installation with missing framework specification

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
@@ -76,7 +76,6 @@ class PaketRestoreIntegrationSpec extends PaketIntegrationBaseSpec {
         runTasksSuccessfully("paketInstall")
 
         assert paketDirectories.every {it.exists()}
-        assert !restoreCacheFile.exists()
 
         when: "deleting packages directory"
         new File(projectDir, dirToDelete).delete()
@@ -86,7 +85,6 @@ class PaketRestoreIntegrationSpec extends PaketIntegrationBaseSpec {
 
         then:
         paketDirectories.every {it.exists()}
-        restoreCacheFile.exists()
 
         where:
         taskToRun = PaketGetPlugin.RESTORE_TASK_NAME

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -120,6 +120,8 @@ class PaketUnityInstall extends ConventionTask {
             fileTree.include("packages/${nuget}/lib/${it}/**")
         })
 
+        fileTree.include("packages/${nuget}/lib/*.dll")
+
         fileTree.exclude("**/*.pdb")
         fileTree.exclude("**/Meta")
         fileTree.files


### PR DESCRIPTION
## Description

This patch fixes an issue with `paketUnityInstall` which only installs
`*.dll` dependencies from nuget when these are located in a framework
directory.

```
packages/Dependency/libs/net35/dep.dll
vs
packages/Dependency/libs/dep.dll
```

This patch just adds a simple rule to also copy these `dll` files over.

## Changes

![FIX] dependency install for dll with missing framework specification
![FIX] integration test with false positive results


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
