### PR TITLE
Improve paket.exe caching

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
@@ -98,7 +98,7 @@ abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
         def result2 = runTasksSuccessfully(taskToRun)
 
         then:
-        !result2.wasUpToDate(bootstrapTaskName)
+        result2.wasUpToDate(bootstrapTaskName)
 
         where:
         taskToRun << bootstrapTestCases

--- a/src/integrationTest/groovy/wooga/gradle/paket/base/PaketBaseIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/base/PaketBaseIntegrationSpec.groovy
@@ -61,4 +61,36 @@ class PaketBaseIntegrationSpec extends PaketIntegrationBaseSpec {
         taskToRun = LifecycleBasePlugin.CLEAN_TASK_NAME
     }
 
+    def "paketBootstrap is [UP-TO-DATE] when paket version is still the same"() {
+        given: "a paket dependency file"
+        createFile("paket.dependencies")
+
+        and: "a empty lock file"
+        createFile("paket.lock")
+
+        and: "a first run of #taskToRun"
+        cleanupPaketDirectory()
+        runTasksSuccessfully(taskToRun)
+
+        when: "running a second time without changes"
+        def result = runTasksSuccessfully(taskToRun)
+
+        then: "bootstrap task was [UP-TO-DATE]"
+        result.wasUpToDate(bootstrapTaskName)
+
+        when: "delete bootstrapper"
+        def paketDir = new File(projectDir, '.paket')
+        def paketBootstrap = new File(paketDir, bootstrapperFileName)
+        paketBootstrap.delete()
+
+        and: "run the task again"
+        def result2 = runTasksSuccessfully(taskToRun)
+
+        then:
+        result2.wasUpToDate(bootstrapTaskName)
+
+        where:
+        taskToRun = "paketBootstrap"
+    }
+
 }

--- a/src/integrationTest/groovy/wooga/gradle/paket/base/PaketBaseIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/base/PaketBaseIntegrationSpec.groovy
@@ -61,36 +61,4 @@ class PaketBaseIntegrationSpec extends PaketIntegrationBaseSpec {
         taskToRun = LifecycleBasePlugin.CLEAN_TASK_NAME
     }
 
-    def "paketBootstrap is [UP-TO-DATE] when paket version is still the same"() {
-        given: "a paket dependency file"
-        createFile("paket.dependencies")
-
-        and: "a empty lock file"
-        createFile("paket.lock")
-
-        and: "a first run of #taskToRun"
-        cleanupPaketDirectory()
-        runTasksSuccessfully(taskToRun)
-
-        when: "running a second time without changes"
-        def result = runTasksSuccessfully(taskToRun)
-
-        then: "bootstrap task was [UP-TO-DATE]"
-        result.wasUpToDate(bootstrapTaskName)
-
-        when: "delete bootstrapper"
-        def paketDir = new File(projectDir, '.paket')
-        def paketBootstrap = new File(paketDir, bootstrapperFileName)
-        paketBootstrap.delete()
-
-        and: "run the task again"
-        def result2 = runTasksSuccessfully(taskToRun)
-
-        then:
-        result2.wasUpToDate(bootstrapTaskName)
-
-        where:
-        taskToRun = "paketBootstrap"
-    }
-
 }

--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.paket.get
 
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.paket.PaketIntegrationBaseSpec
@@ -91,6 +92,8 @@ class PaketRestoreIntegrationSpec extends PaketIntegrationBaseSpec {
         dirToDelete << paketDirectories
     }
 
+
+    @Ignore //reason see issue https://github.com/wooga/atlas-paket/issues/53
     @Unroll
     def "task :#taskToRun caches last restore state"() {
         given: "a paket dependency file"

--- a/src/main/groovy/wooga/gradle/paket/base/tasks/PaketBootstrap.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/PaketBootstrap.groovy
@@ -53,9 +53,12 @@ class PaketBootstrap extends AbstractPaketTask {
     @Input
     String paketVersion
 
+    @Input
+    File paketExecutable
+
     @OutputFiles
     FileCollection getOutputFiles() {
-        return project.files(getExecutable())
+        return project.files(getExecutable(), getPaketExecutable())
     }
     
     void setPaketVersion(String value) {


### PR DESCRIPTION
## Description

Gradle tends to invalidate it's buildcache whenever it is unclear who produced specific task outputs. This leads to a lot of redownload requests for the paket.exe during tests. This patch adds a custom `upToDateWhen` spec which checks if the paket.exe is available and if the version is the correct one. I have to invoke the tool once because it's the fastest cross platform solution.

## Changes

* ![IMPROVE] paket.exe caching

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
