### PR TITLE
Add option to include assembly definition files for paketInstall

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
@@ -22,6 +22,7 @@ import nebula.test.functional.ExecutionResult
 import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.paket.get.PaketGetPlugin
+import wooga.gradle.paket.unity.tasks.PaketUnityInstall
 
 class PaketUnityIntegrationSpec extends IntegrationSpec {
 
@@ -116,31 +117,8 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
             ${applyPlugin(PaketGetPlugin)}
         """.stripIndent()
 
-        and: "apply paket unity plugin to get paket unity install task"
-        buildFile << """
-            ${applyPlugin(PaketUnityPlugin)}
-        """.stripIndent()
-
-        and: "paket dependency file and lock"
-        def dependencies = createFile("paket.dependencies")
-
-
-        dependencies << """
-        source https://nuget.org/api/v2
-        nuget ${dependencyName}
-          """.stripIndent()
-
-        def lockFile = createFile("paket.lock")
-        lockFile << """${dependencyName}""".stripIndent()
-
-        and: "paket unity references file "
-        def references = createFile("${unityProjectName}/paket.unity3d.references")
-        references << """
-        ${dependencyName}
-        """.stripIndent()
-
-        and: "dependency package with file"
-        createFile("packages/${dependencyName}/content/${dependencyName}.cs")
+        and: "setup paket configuration"
+        setupPaketProject(dependencyName, unityProjectName)
 
         when:
         def result = runTasksSuccessfully(PaketUnityPlugin.INSTALL_TASK_NAME)
@@ -149,6 +127,72 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
 
         then:
         result.wasExecuted(PaketUnityPlugin.INSTALL_TASK_NAME)
+    }
+
+    @Unroll("Copy assembly definitions when includeAssemblyDefinitions is #includeAssemblyDefinitions and set in #configurationString")
+    def "copy assembly definition files"() {
+
+        given: "apply paket get plugin to get paket install task"
+        buildFile << """
+            ${applyPlugin(PaketGetPlugin)}
+        """.stripIndent()
+
+        buildFile << """
+            ${configurationString} {                 
+                    includeAssemblyDefinitions = ${includeAssemblyDefinitions}                  
+            }      
+        """.stripIndent()
+
+        and: "setup paket configuration"
+        setupPaketProject(dependencyName, unityProjectName)
+
+        and: "setup assembly definition file in package"
+        def asmdefFileName = "${dependencyName}.${PaketUnityInstall.assemblyDefinitionFileExtension}"
+        def inputAsmdefFile = createFile("packages/${dependencyName}/content/${asmdefFileName}")
+        assert inputAsmdefFile.exists()
+
+        when:
+        def result = runTasksSuccessfully(PaketUnityPlugin.INSTALL_TASK_NAME)
+        def outputDir = "${unityProjectName}/Assets/Paket.Unity3D/${dependencyName}"
+        def packagesDir = new File(projectDir, outputDir)
+        assert packagesDir.exists()
+
+        then:
+        result.wasExecuted(PaketUnityPlugin.INSTALL_TASK_NAME)
+        def outputAsmdefFilePath = "${packagesDir}/${asmdefFileName}"
+        def outputAsmdefFile = new File(outputAsmdefFilePath)
+        includeAssemblyDefinitions == outputAsmdefFile.exists()
+
+        where:
+        baseConfigurationString | includeAssemblyDefinitions
+        "paketUnity" | true
+        "paketUnity" | false
+        "project.tasks.getByName(#taskName%%)" | true
+        "project.tasks.getByName(#taskName%%)" | false
+
+        unityProjectName = "Test.Project"
+        taskName = PaketUnityPlugin.INSTALL_TASK_NAME + unityProjectName
+        dependencyName = "Wooga.TestDependency"
+        configurationString = baseConfigurationString.replace("#taskName%%", "'${taskName}'")
+    }
+
+    private void setupPaketProject(dependencyName, unityProjectName) {
+
+        def dependencies = createFile("paket.dependencies")
+        dependencies << """
+        source https://nuget.org/api/v2
+        nuget ${dependencyName}
+          """.stripIndent()
+
+        def lockFile = createFile("paket.lock")
+        lockFile << """${dependencyName}""".stripIndent()
+
+        def references = createFile("${unityProjectName}/paket.unity3d.references")
+        references << """
+        ${dependencyName}
+        """.stripIndent()
+
+        createFile("packages/${dependencyName}/content/${dependencyName}.cs")
     }
 
     static boolean hasNoSource(ExecutionResult result, String taskName) {

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -83,6 +83,7 @@ class PaketUnityPlugin implements Plugin<Project> {
                 group = GROUP
                 description = "Installs dependencies for Unity3d project ${referenceFile.parentFile.name} "
                 conventionMapping.map("paketOutputDirectoryName", { extension.getPaketOutputDirectoryName() })
+                conventionMapping.map("includeAssemblyDefinitions", { extension.getIncludeAssemblyDefinitions() })
                 conventionMapping.map("assemblyDefinitionFileStrategy", { extension.getAssemblyDefinitionFileStrategy() })
                 frameworks = extension.getPaketDependencies().getFrameworks()
                 lockFile = extension.getPaketLockFile()

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
@@ -55,4 +55,15 @@ interface PaketUnityPluginExtension extends PaketPluginExtension {
      * @param strategy the strategy to be used
      */
     void setAssemblyDefinitionFileStrategy(AssemblyDefinitionFileStrategy strategy)
+
+    /**
+     * Sets whether assembly definition files should be included during installation
+     * @param value
+     */
+    void setIncludeAssemblyDefinitions(Boolean value)
+
+    /**
+     * @return Whether assembly definition files should be included during installation
+     */
+    Boolean getIncludeAssemblyDefinitions()
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/AssemblyDefinitionFileStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/AssemblyDefinitionFileStrategy.groovy
@@ -19,4 +19,5 @@ package wooga.gradle.paket.unity.internal
 
 enum AssemblyDefinitionFileStrategy {
     manual, disabled
+
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -30,6 +30,8 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
     protected AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
     protected String customPaketOutputDirectory
+    protected Boolean includeAssemblyDefinitions
+
 
     DefaultPaketUnityPluginExtension(Project project,final PaketDependencyHandler dependencyHandler) {
         super(project, dependencyHandler)
@@ -59,5 +61,15 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
     @Override
     void setAssemblyDefinitionFileStrategy(AssemblyDefinitionFileStrategy strategy) {
         assemblyDefinitionFileStrategy = strategy
+    }
+
+    @Override
+    void setIncludeAssemblyDefinitions(Boolean value) {
+        includeAssemblyDefinitions = value
+    }
+
+    @Override
+    Boolean getIncludeAssemblyDefinitions() {
+        includeAssemblyDefinitions
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -77,10 +77,18 @@ class PaketUnityInstall extends ConventionTask {
     @Input
     String paketOutputDirectoryName
 
+    /**
+     * Whether assembly definition files (.asmdef) should be included during installation
+     */
+    @Input
+    Boolean includeAssemblyDefinitions = false
+
     @Input
     AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
 
     File projectRoot
+
+    public final static String assemblyDefinitionFileExtension = "asmdef"
 
     /**
      * @return the installation output directory
@@ -124,7 +132,13 @@ class PaketUnityInstall extends ConventionTask {
 
         fileTree.exclude("**/*.pdb")
         fileTree.exclude("**/Meta")
-        fileTree.files
+
+        if (!getIncludeAssemblyDefinitions()) {
+            fileTree.exclude("**/*.${assemblyDefinitionFileExtension}")
+        }
+
+        def files = fileTree.files
+        return files
     }
 
     PaketUnityInstall() {


### PR DESCRIPTION
## Description

Adds a property to the paketUnity plugin that allows including assembly definition files on a paket install.

## Changes
* ![IMPROVE] PaketUnityPlugin
* ![IMPROVE] PaketUnityInstall
* ![IMPROVE] ASsemblyDefinitionFileStrategy

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
