### PR TITLE
Fix missing default value for includeAssemblyDefinitions

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -30,8 +30,7 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
     protected AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
     protected String customPaketOutputDirectory
-    protected Boolean includeAssemblyDefinitions
-
+    protected Boolean includeAssemblyDefinitions = false
 
     DefaultPaketUnityPluginExtension(Project project,final PaketDependencyHandler dependencyHandler) {
         super(project, dependencyHandler)


### PR DESCRIPTION
## Description

Fixes missing default value for the includeAssemblyDefinitions property.

## Changes
* ![FIX] DefaultPaketUnityPluginExtension: Set default for includeAssemblyDefinitions property

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
