### PR TITLE
Normalize task names generated by unity plugin

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
@@ -171,7 +171,7 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
         "project.tasks.getByName(#taskName%%)" | false
 
         unityProjectName = "Test.Project"
-        taskName = PaketUnityPlugin.INSTALL_TASK_NAME + unityProjectName
+        taskName = PaketUnityPlugin.generateProjectTaskName(unityProjectName)
         dependencyName = "Wooga.TestDependency"
         configurationString = baseConfigurationString.replace("#taskName%%", "'${taskName}'")
     }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -33,10 +33,8 @@ import wooga.gradle.paket.unity.tasks.PaketUnityInstall
  * Example:
  * <pre>
  * {@code
- *     plugins {
- *         id 'net.wooga.paket-unity' version '0.10.1'
- *     }
- * }
+ *     plugins {*         id 'net.wooga.paket-unity' version '0.10.1'
+ *}*}
  * </pre>
  */
 class PaketUnityPlugin implements Plugin<Project> {
@@ -46,6 +44,8 @@ class PaketUnityPlugin implements Plugin<Project> {
     static final String GROUP = "PaketUnity"
     static final String EXTENSION_NAME = 'paketUnity'
     static final String INSTALL_TASK_NAME = "paketUnityInstall"
+
+    static final String taskNameSeparator = "_"
 
     @Override
     void apply(Project project) {
@@ -78,7 +78,7 @@ class PaketUnityPlugin implements Plugin<Project> {
         }
 
         extension.paketReferencesFiles.each { referenceFile ->
-            def task = project.tasks.create(INSTALL_TASK_NAME + referenceFile.parentFile.name, PaketUnityInstall)
+            def task = project.tasks.create(generateProjectTaskName(referenceFile.parentFile.name), PaketUnityInstall)
             task.with {
                 group = GROUP
                 description = "Installs dependencies for Unity3d project ${referenceFile.parentFile.name} "
@@ -109,5 +109,10 @@ class PaketUnityPlugin implements Plugin<Project> {
 
             [paketInstall, paketRestore].each configClosure
         }
+    }
+
+    static String generateProjectTaskName(name) {
+        return (INSTALL_TASK_NAME + name)
+                .replaceAll(/\./, taskNameSeparator)
     }
 }


### PR DESCRIPTION
## Description

Ensures task names don't use '.', which wille be replacd by '_'.

## Changes
* ![UPDATE] PaletUnityPlugin

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
