### PR TITLE
Make sure items in paket references are trimmed

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferences.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferences.groovy
@@ -30,7 +30,7 @@ class PaketUnityReferences {
         referencesContent.eachLine { line ->
 
             if(!line.empty){
-                nugets << line
+                nugets << line.trim()
             }
         }
     }

--- a/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferencesSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferencesSpec.groovy
@@ -1,0 +1,25 @@
+package wooga.gradle.paket.base.utils.internal
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+import wooga.gradle.paket.base.utils.internal.PaketTemplate
+
+class PaketUnityReferencesSpec extends Specification {
+
+    @Unroll
+    def "ensure items are trimmed"() {
+
+        when:
+        def refs = new PaketUnityReferences(content)
+
+        then:
+        refs.nugets == nugets
+
+        where:
+        content               | nugets
+        "A1\nA2\nA3\n"        | ["A1", "A2", "A3"]
+        " A1 \nA2\nA3\n"      | ["A1", "A2", "A3"]
+        " A1 \n A2 \nA3   \n" | ["A1", "A2", "A3"]
+    }
+}


### PR DESCRIPTION
## Description

Ensures items parsed in paket unity refs are trimmed.

## Changes
* ![FIX] PaketUnityReferences

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
