### PR TITLE
Add option to include tests in paket install

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,8 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "java:gradle"
-    directory: "/"
-    update_schedule: "daily"
-    ignored_updates:
-      - match:
-          dependency_name: "org.spockframework:spock-core"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+registries:
+  maven-repository-wooga-jfrog-io-wooga-atlas-maven:
+    type: maven-repository
+    url: https://wooga.jfrog.io/wooga/atlas-maven
+    username: atlas
+    password: "${{secrets.MAVEN_REPOSITORY_WOOGA_JFROG_IO_WOOGA_ATLAS_MAVEN_PASSWORD}}"
+
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: org.spockframework:spock-core
+    versions:
+    - ">= 0"
+  registries:
+  - maven-repository-wooga-jfrog-io-wooga-atlas-maven

--- a/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketLock.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketLock.groovy
@@ -17,6 +17,9 @@
 
 package wooga.gradle.paket.base.utils.internal
 
+/**
+ * The parsed contents of paket.lock file
+ */
 class PaketLock {
 
     enum SourceType {
@@ -35,7 +38,10 @@ class PaketLock {
 
     enum LineType {
 
-        TYPE(0), REMOTE(1), NAME(2), DEPENDENCY(3)
+        TYPE(0),
+        REMOTE(1),
+        NAME(2),
+        DEPENDENCY(3)
 
         private final int value
 
@@ -107,15 +113,25 @@ class PaketLock {
         return false
     }
 
+    /**
+     * @param id The identifier for the dependency
+     * @return All the direct and transitive dependencies used by this dependency
+     */
     List<String> getDependencies(SourceType source, String id) {
-        content[source.getValue()] && content[source.getValue()][id] ? content[source.getValue()][id] as List<String> : []
+        // If the lock file has a reference with the given id,
+        // retrieve all its dependencies
+        content[source.value] && content[source.value][id]
+                ? content[source.value][id] as List<String>
+                : []
     }
 
+    /**
+     * @return Given a list of package references, returns all their dependencies
+     */
     List<String> getAllDependencies(List<String> references) {
-        def ref = references.collect { reference ->
+        def result = references.collect { reference ->
             [reference, getAllDependencies(getDependencies(SourceType.NUGET, reference))]
         }
-
-        ref.flatten().unique()
+        result.flatten().unique()
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferences.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferences.groovy
@@ -17,21 +17,106 @@
 
 package wooga.gradle.paket.base.utils.internal
 
+
+import java.util.logging.Logger
+
+/**
+ * A single reference for an Unity WDK package
+ */
+class PaketUnityReference {
+
+    private static final Logger logger = Logger.getLogger(PaketUnityReference.class.name)
+
+    String name
+    Boolean includeTests = false
+    Boolean includeAssemblies = false
+
+    PaketUnityReference(String name) {
+        this.name = name
+    }
+
+    static PaketUnityReference Parse(String text) {
+
+        String pattern = /\s?(?<name>[A-Za-z0-9\.]+)\s*?(\s+(\[(?<properties>.*?)\]))?$/
+
+        def matcher = text =~ pattern
+        if (matcher.count == 0) {
+            logger.warning("Could not parse a reference from ${text}")
+            return null
+        }
+
+        def (_, String name, __, ___, String properties) = matcher[0]
+        PaketUnityReference result = new PaketUnityReference(name)
+
+        if (properties) {
+            try {
+                def map = parseMap(properties)
+                if (map) {
+                    result.includeTests = Boolean.parseBoolean(map["includeTests"]) ?: false
+                    result.includeAssemblies = Boolean.parseBoolean(map["includeAssemblies"]) ?: false
+                }
+            }
+            catch (Exception e) {
+                logger.warning("Failed to parse map from ${text}:\n${e}")
+            }
+        }
+
+        result
+    }
+
+    /***
+     * @param input A String containing a groovy map in the format "key:value,key:value"
+     * @return A map containing the parsed string's key-value pairs
+     */
+    static Map<String, ?> parseMap(String input) {
+        (input =~ /\s*,?\s*([^:]+?)\s*:\s*([^,]*)\s*/)
+                .collect { [it[1], it[2].trim()] }
+                .collectEntries()
+    }
+}
+
+/**
+ * A parsed <i>paket.unity3d.references</i> file, which contains
+ * references to the dependencies used by a project.
+ * These are used by this plugin during a paketInstall invocation
+ */
 class PaketUnityReferences {
 
-    public List<String> nugets
+    private final Map<String, PaketUnityReference> referencesByName
+    private final List<PaketUnityReference> references
+
+    List<PaketUnityReference> getReferences() {
+        references
+    }
+
+    List<String> getReferenceNames() {
+        references.collect({it -> it.name})
+    }
 
     PaketUnityReferences(File referencesFile) {
         this(referencesFile.text)
     }
 
     PaketUnityReferences(String referencesContent) {
-        nugets = []
-        referencesContent.eachLine { line ->
+        references = []
+        referencesByName = [:]
 
-            if(!line.empty){
-                nugets << line.trim()
+        referencesContent.eachLine { line ->
+            if (!line.empty) {
+                PaketUnityReference ref = PaketUnityReference.Parse(line.trim())
+                if (ref != null) {
+                    references << ref
+                    referencesByName.put(ref.name, ref)
+                }
             }
         }
+    }
+
+    Boolean containsReference(String name) {
+        referencesByName.containsKey(name)
+    }
+
+    PaketUnityReference getReference(String name) {
+        referencesByName.containsKey(name) ? referencesByName[name] : null
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -80,6 +80,7 @@ class PaketUnityPlugin implements Plugin<Project> {
                 t.description = "Installs dependencies for Unity3d project ${referenceFile.parentFile.name} "
                 t.conventionMapping.map("paketOutputDirectoryName", { extension.getPaketOutputDirectoryName() })
                 t.conventionMapping.map("includeAssemblyDefinitions", { extension.getIncludeAssemblyDefinitions() })
+                t.conventionMapping.map("includeTests", { extension.getIncludeTests() })
                 t.conventionMapping.map("assemblyDefinitionFileStrategy", { extension.getAssemblyDefinitionFileStrategy() })
                 t.frameworks = extension.getPaketDependencies().getFrameworks()
                 t.lockFile = extension.getPaketLockFile()

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
@@ -66,4 +66,15 @@ interface PaketUnityPluginExtension extends PaketPluginExtension {
      * @return Whether assembly definition files should be included during installation
      */
     Boolean getIncludeAssemblyDefinitions()
+
+    /**
+     * Sets whether test assemblies should be included during installation
+     * @param value
+     */
+    void setIncludeTests(Boolean value)
+
+    /**
+     * @return Whether test assemblies should be included during installation
+     */
+    Boolean getIncludeTests()
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -31,6 +31,7 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
     protected AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
     protected String customPaketOutputDirectory
     protected Boolean includeAssemblyDefinitions = false
+    protected Boolean includeTests = false
 
     DefaultPaketUnityPluginExtension(Project project,final PaketDependencyHandler dependencyHandler) {
         super(project, dependencyHandler)
@@ -70,5 +71,15 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
     @Override
     Boolean getIncludeAssemblyDefinitions() {
         includeAssemblyDefinitions
+    }
+
+    @Override
+    void setIncludeTests(Boolean value) {
+        includeTests = value
+    }
+
+    @Override
+    Boolean getIncludeTests() {
+        includeTests
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -17,15 +17,15 @@
 
 package wooga.gradle.paket.unity.tasks
 
-import groovy.transform.Internal
+
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Action
+import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
@@ -45,13 +45,11 @@ import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
  * Example:
  * <pre>
  * {@code
- *     task unityInstall(type:wooga.gradle.paket.unity.tasks.PaketUnityInstall) {
- *         referencesFile = file('paket.unity3D.references')
+ *     task unityInstall(type:wooga.gradle.paket.unity.tasks.PaketUnityInstall) {*         referencesFile = file('paket.unity3D.references')
  *         lockFile = file('../paket.lock')
  *         frameworks = ["net11", "net20", "net35"]
  *         paketOutputDirectoryName = "PaketUnity3D"
- *     }
- * }
+ *}*}
  * </pre>
  */
 class PaketUnityInstall extends ConventionTask {
@@ -86,12 +84,17 @@ class PaketUnityInstall extends ConventionTask {
     @Input
     Boolean includeAssemblyDefinitions = false
 
+    /**
+     * Whether test assemblies (in $PACKAGE/Tests) should be included during installation
+     */
+    @Input
+    Boolean includeTests = false
+
     @Input
     AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
 
     public final static String assemblyDefinitionFileExtension = "asmdef"
-
-    public final static String assemblyDefinitionFileExtension = "asmdef"
+    public final static String testsDirectoryName = "Tests"
 
     /**
      * @return the installation output directory
@@ -107,23 +110,74 @@ class PaketUnityInstall extends ConventionTask {
     @InputFiles
     FileCollection getInputFiles() {
         Set<File> files = []
+
+
+        // By convention, the root of the Unity project will have a
+        // paket.references file that we use to decide what files from the packages we will copy
+        // into the project
         def references = new PaketUnityReferences(getReferencesFile())
 
+        // If there's no lock file, do nothing
         if (!getLockFile().exists()) {
             return null
         }
 
+        // Retrieve all dependencies by using the lock file,
+        // filtering them and giving only unique entries
         def locks = new PaketLock(getLockFile())
-        def dependencies = locks.getAllDependencies(references.nugets)
+        def dependencies = locks.getAllDependencies(references.referenceNames)
         dependencies.each { nuget ->
-            def depFiles = getFilesForPackage(nuget)
-            files << depFiles
+
+            // An optional action to invoke while packaging files
+            Action<? super ConfigurableFileTree> onPackage = null
+            // TODO: Include logging for when tests/assemblies are included
+
+            // If it's an unity wdk package, we have additional properties for it
+            // which we can use to further filter the files
+            if (references.containsReference(nuget)) {
+
+                def ref = references.getReference(nuget)
+                onPackage = { fileTree ->
+
+                    // TESTS
+                    if (!ref.includeTests && !getIncludeTests()) {
+                        // Exclude the Tests directory on the second level of the project,
+                        // since wdks conventionally have the layout:
+                        // $WDK/Runtime
+                        // $WDK/Editor
+                        // $WDK/Tests
+                        fileTree.exclude("**/${nuget}/content/*/${testsDirectoryName}/**/*")
+                    }
+                    else{
+                        logger.info("Including tests from ${nuget}")
+                    }
+
+                    // ASSEMBLY DEFINITION FILES
+                    if (!ref.includeAssemblies && !getIncludeAssemblyDefinitions()) {
+                        // Exclude all assembly definition files from the project
+                        fileTree.exclude("**/${nuget}/content/*.${assemblyDefinitionFileExtension}")
+                    }
+                    else{
+                        logger.info("Including assembly definition files from ${nuget}")
+                    }
+                }
+            }
+
+            def packageFiles = getFilesFromPackage(nuget, onPackage)
+            files << packageFiles
         }
 
         project.files(files)
     }
 
-    Set<File> getFilesForPackage(String nuget) {
+    /**
+     * @param nuget The name of the nuget package's directory
+     * @return Given the name of a (downloaded) nuget package, returns the path to all
+     * the applicable files from it that should be copied to the project
+     */
+    Set<File> getFilesFromPackage(String nuget, Action<? super ConfigurableFileTree> action = null) {
+
+        logger.info("Including files from nuget package: ${nuget}")
         def fileTree = project.fileTree(dir: project.projectDir)
         fileTree.include("packages/${nuget}/content/**")
 
@@ -136,8 +190,8 @@ class PaketUnityInstall extends ConventionTask {
         fileTree.exclude("**/*.pdb")
         fileTree.exclude("**/Meta")
 
-        if (!getIncludeAssemblyDefinitions()) {
-            fileTree.exclude("**/*.${assemblyDefinitionFileExtension}")
+        if (action != null) {
+            action.execute(fileTree)
         }
 
         def files = fileTree.files
@@ -149,6 +203,10 @@ class PaketUnityInstall extends ConventionTask {
         group = PaketUnityPlugin.GROUP
     }
 
+    /**
+     * Copies all the resolved nuget package files from their source directories
+     * onto the project
+     */
     @TaskAction
     protected performCopy(IncrementalTaskInputs inputs) {
 
@@ -163,7 +221,7 @@ class PaketUnityInstall extends ConventionTask {
         inputs.outOfDate(new Action<InputFileDetails>() {
             @Override
             void execute(InputFileDetails outOfDate) {
-                if(inputFiles.contains(outOfDate.file)) {
+                if (inputFiles.contains(outOfDate.file)) {
                     def outputPath = transformInputToOutputPath(outOfDate.file, project.file("packages"))
                     logger.info("${outOfDate.added ? "install" : "update"}: ${outputPath}")
                     FileUtils.copyFile(outOfDate.file, outputPath)
@@ -196,7 +254,7 @@ class PaketUnityInstall extends ConventionTask {
     protected void cleanOutputDirectory() {
         def tree = project.fileTree(getOutputDirectory())
 
-        if(getAssemblyDefinitionFileStrategy() == AssemblyDefinitionFileStrategy.manual) {
+        if (getAssemblyDefinitionFileStrategy() == AssemblyDefinitionFileStrategy.manual) {
             tree.exclude("**/*.asmdef")
             tree.exclude("**/*.asmdef.meta")
         }

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -91,6 +91,8 @@ class PaketUnityInstall extends ConventionTask {
 
     public final static String assemblyDefinitionFileExtension = "asmdef"
 
+    public final static String assemblyDefinitionFileExtension = "asmdef"
+
     /**
      * @return the installation output directory
      */

--- a/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferencesSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferencesSpec.groovy
@@ -1,11 +1,38 @@
 package wooga.gradle.paket.base.utils.internal
 
-import spock.lang.Shared
+
 import spock.lang.Specification
 import spock.lang.Unroll
-import wooga.gradle.paket.base.utils.internal.PaketTemplate
 
 class PaketUnityReferencesSpec extends Specification {
+
+    @Unroll
+    def "parses references"() {
+
+        when:
+        def ref = PaketUnityReference.Parse(line)
+        expected.includeTests = includeTests
+        expected.includeAssemblies = includeAssemblies
+
+        then:
+        ref != null
+        ref.name == expected.name
+        ref.includeTests == expected.includeTests
+        ref.includeAssemblies == expected.includeAssemblies
+
+        where:
+        line                                                               | expected                           | includeTests | includeAssemblies
+        "Foo.Bar"                                                          | new PaketUnityReference("Foo.Bar") | false        | false
+        "    Foo.Bar   "                                                   | new PaketUnityReference("Foo.Bar") | false        | false
+        "   Foo.Bar"                                                       | new PaketUnityReference("Foo.Bar") | false        | false
+        "Foo.Bar   "                                                       | new PaketUnityReference("Foo.Bar") | false        | false
+        "Foo.Bar [includeTests:true]"                                      | new PaketUnityReference("Foo.Bar") | true         | false
+        "Foo.Bar   [includeAssemblies:true]"                               | new PaketUnityReference("Foo.Bar") | false        | true
+        "Foo.Bar   [includeAssemblies:true,includeTests:true]"             | new PaketUnityReference("Foo.Bar") | true         | true
+        "   Foo.Bar   [includeAssemblies : true,  includeTests: true]"     | new PaketUnityReference("Foo.Bar") | true         | true
+        "   Foo.Bar   [  includeAssemblies : true,  includeTests: true  ]" | new PaketUnityReference("Foo.Bar") | true         | true
+
+    }
 
     @Unroll
     def "ensure items are trimmed"() {
@@ -14,10 +41,10 @@ class PaketUnityReferencesSpec extends Specification {
         def refs = new PaketUnityReferences(content)
 
         then:
-        refs.nugets == nugets
+        refs.referenceNames == references
 
         where:
-        content               | nugets
+        content               | references
         "A1\nA2\nA3\n"        | ["A1", "A2", "A3"]
         " A1 \nA2\nA3\n"      | ["A1", "A2", "A3"]
         " A1 \n A2 \nA3   \n" | ["A1", "A2", "A3"]


### PR DESCRIPTION
## Description

Adds the includeTests property for our Unity packages (in addition to the existing includeAssemblies)

Overhauls how the paket.unity3d.references are parsed:

- Backwards compatible with existing declarations
- Provides the configuration of properties per reference (rather than just at task level)

## Changes
* ![IMPROVE] PaketUnityPlugin
* ![IMPROVE] PaketUnityInstall
* ![UPDATE] PaketUnityReferences

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"