### PR TITLE
Upgrade plugin to gradle 6.8.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id "net.wooga.plugins" version "1.5.0"
+    id "net.wooga.plugins" version "2.0.0"
 }
 
 group 'net.wooga.gradle'
@@ -65,9 +65,9 @@ github {
 }
 
 dependencies {
-    testCompile('org.jfrog.artifactory.client:artifactory-java-client-services:2.+') {
+    testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:2.+') {
         exclude module: 'logback-classic'
     }
 
-    compile('com.google.guava:guava:19.0')
+    implementation('com.google.guava:guava:19.0')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -20,4 +20,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/gradle_check_versions.sh
+++ b/gradle_check_versions.sh
@@ -1,15 +1,40 @@
 #!/usr/bin/env bash
 
-versions=("4.0" "4.1" "4.2" "4.3" "4.4" "4.5" "4.6" "4.7" "4.8" "4.9" "4.10")
+#
+# Copyright 2018-2021 Wooga GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+versions=("5.0" "5.1" "5.2" "5.3" "5.4" "5.5" "5.6.4" "6.0" "6.1" "6.2" "6.3" "6.4" "6.5" "6.6" "6.7")
+
+rm -fr build/reports
 for i in "${versions[@]}"
 do
     echo "test gradle version $i"
+    GRADLE_VERSION=$i ./gradlew test &> /dev/null
+    status=$?
+    mkdir -p "build/reports/$i"
+    mv build/reports/test "build/reports/$i"
+    if [ $status -ne 0 ]; then
+        echo "test error $i"
+    fi
+
     GRADLE_VERSION=$i ./gradlew integrationTest &> /dev/null
     status=$?
     mkdir -p "build/reports/$i"
     mv build/reports/integrationTest "build/reports/$i"
     if [ $status -ne 0 ]; then
-        echo "test error $i"
+        echo "integrationTest error $i"
     fi
 done

--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityChangeSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityChangeSpec.groovy
@@ -27,7 +27,7 @@ import wooga.gradle.paket.get.PaketGetPlugin
 
 class PaketUnityChangeSpec extends IntegrationSpec {
 
-    final static String STD_OUT_ALL_OUT_OF_DATE = "All input files are considered out-of-date for incremental task"
+    final static String STD_OUT_ALL_OUT_OF_DATE = "The input changes require a full rebuild for incremental task"
 
     @PaketDependency(projectDependencies = ["D1", "D2", "D3"])
     PaketDependencySetup paketSetup

--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
@@ -22,6 +22,7 @@ import nebula.test.functional.ExecutionResult
 import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.paket.get.PaketGetPlugin
+import wooga.gradle.paket.unity.tasks.PaketUnityInstall
 
 class PaketUnityIntegrationSpec extends IntegrationSpec {
 
@@ -116,31 +117,8 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
             ${applyPlugin(PaketGetPlugin)}
         """.stripIndent()
 
-        and: "apply paket unity plugin to get paket unity install task"
-        buildFile << """
-            ${applyPlugin(PaketUnityPlugin)}
-        """.stripIndent()
-
-        and: "paket dependency file and lock"
-        def dependencies = createFile("paket.dependencies")
-
-
-        dependencies << """
-        source https://nuget.org/api/v2
-        nuget ${dependencyName}
-          """.stripIndent()
-
-        def lockFile = createFile("paket.lock")
-        lockFile << """${dependencyName}""".stripIndent()
-
-        and: "paket unity references file "
-        def references = createFile("${unityProjectName}/paket.unity3d.references")
-        references << """
-        ${dependencyName}
-        """.stripIndent()
-
-        and: "dependency package with file"
-        createFile("packages/${dependencyName}/content/${dependencyName}.cs")
+        and: "setup paket configuration"
+        setupPaketProject(dependencyName, unityProjectName)
 
         when:
         def result = runTasksSuccessfully(PaketUnityPlugin.INSTALL_TASK_NAME)
@@ -149,6 +127,72 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
 
         then:
         result.wasExecuted(PaketUnityPlugin.INSTALL_TASK_NAME)
+    }
+
+    @Unroll("Copy assembly definitions when includeAssemblyDefinitions is #includeAssemblyDefinitions and set in #configurationString")
+    def "copy assembly definition files"() {
+
+        given: "apply paket get plugin to get paket install task"
+        buildFile << """
+            ${applyPlugin(PaketGetPlugin)}
+        """.stripIndent()
+
+        buildFile << """
+            ${configurationString} {                 
+                    includeAssemblyDefinitions = ${includeAssemblyDefinitions}                  
+            }      
+        """.stripIndent()
+
+        and: "setup paket configuration"
+        setupPaketProject(dependencyName, unityProjectName)
+
+        and: "setup assembly definition file in package"
+        def asmdefFileName = "${dependencyName}.${PaketUnityInstall.assemblyDefinitionFileExtension}"
+        def inputAsmdefFile = createFile("packages/${dependencyName}/content/${asmdefFileName}")
+        assert inputAsmdefFile.exists()
+
+        when:
+        def result = runTasksSuccessfully(PaketUnityPlugin.INSTALL_TASK_NAME)
+        def outputDir = "${unityProjectName}/Assets/Paket.Unity3D/${dependencyName}"
+        def packagesDir = new File(projectDir, outputDir)
+        assert packagesDir.exists()
+
+        then:
+        result.wasExecuted(PaketUnityPlugin.INSTALL_TASK_NAME)
+        def outputAsmdefFilePath = "${packagesDir}/${asmdefFileName}"
+        def outputAsmdefFile = new File(outputAsmdefFilePath)
+        includeAssemblyDefinitions == outputAsmdefFile.exists()
+
+        where:
+        baseConfigurationString | includeAssemblyDefinitions
+        "paketUnity" | true
+        "paketUnity" | false
+        "project.tasks.getByName(#taskName%%)" | true
+        "project.tasks.getByName(#taskName%%)" | false
+
+        unityProjectName = "Test.Project"
+        taskName = PaketUnityPlugin.INSTALL_TASK_NAME + unityProjectName
+        dependencyName = "Wooga.TestDependency"
+        configurationString = baseConfigurationString.replace("#taskName%%", "'${taskName}'")
+    }
+
+    private void setupPaketProject(dependencyName, unityProjectName) {
+
+        def dependencies = createFile("paket.dependencies")
+        dependencies << """
+        source https://nuget.org/api/v2
+        nuget ${dependencyName}
+          """.stripIndent()
+
+        def lockFile = createFile("paket.lock")
+        lockFile << """${dependencyName}""".stripIndent()
+
+        def references = createFile("${unityProjectName}/paket.unity3d.references")
+        references << """
+        ${dependencyName}
+        """.stripIndent()
+
+        createFile("packages/${dependencyName}/content/${dependencyName}.cs")
     }
 
     static boolean hasNoSource(ExecutionResult result, String taskName) {

--- a/src/main/groovy/wooga/gradle/paket/base/PaketBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/PaketBasePlugin.groovy
@@ -28,7 +28,6 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Delete
-import org.gradle.buildinit.tasks.internal.TaskConfiguration
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import wooga.gradle.paket.base.dependencies.internal.DefaultPaketDependencyHandler
@@ -53,6 +52,8 @@ class PaketBasePlugin implements Plugin<Project> {
     static final String INIT_TASK_NAME = "paketInit"
     static final String PAKET_DEPENDENCIES_TASK_NAME = "paketDependencies"
     static final String PAKET_CONFIGURATION = "nupkg"
+
+    static final String TASK_GROUP_NAME = "Build Setup"
 
     @Override
     void apply(Project project) {
@@ -129,7 +130,7 @@ class PaketBasePlugin implements Plugin<Project> {
     }
 
     private static void addInitTask(final Project project, PaketPluginExtension extension) {
-        final task = project.tasks.create(name: INIT_TASK_NAME, type: PaketInit, group: TaskConfiguration.GROUP)
+        final task = project.tasks.create(name: INIT_TASK_NAME, type: PaketInit, group: TASK_GROUP_NAME)
         task.conventionMapping.map("dependenciesFile", { extension.getPaketDependenciesFile() })
     }
 

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyConfiguration.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.paket.base.dependencies.internal
 import org.gradle.api.Action
 import org.gradle.api.Named
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.internal.Actions
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
@@ -34,7 +35,7 @@ class DefaultPaketDependencyConfiguration extends AbstractNamedDomainObjectConta
     private final PaketDependencyFactory dependencyFactory
 
     DefaultPaketDependencyConfiguration(final String name, Instantiator instantiator = null) {
-        super(PaketDependency.class, instantiator ?: DirectInstantiator.INSTANCE)
+        super(PaketDependency.class, instantiator ?: DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)
         this.name = name
         this.dependencyFactory = instantiator.newInstance(PaketDependencyFactory, instantiator)
     }

--- a/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyConfigurationContainer.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/dependencies/internal/DefaultPaketDependencyConfigurationContainer.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.paket.base.dependencies.internal
 
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 import org.gradle.internal.reflect.Instantiator
@@ -29,7 +30,7 @@ class DefaultPaketDependencyConfigurationContainer extends AbstractNamedDomainOb
     private final Instantiator instantiator
 
     DefaultPaketDependencyConfigurationContainer(final Instantiator instantiator) {
-        super(PaketDependencyConfiguration.class, instantiator)
+        super(PaketDependencyConfiguration.class, instantiator, CollectionCallbackActionDecorator.NOOP)
         this.instantiator = instantiator
     }
 

--- a/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepository.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepository.groovy
@@ -19,7 +19,10 @@ package wooga.gradle.paket.base.repository.internal
 
 import com.google.common.collect.Lists
 import groovy.transform.EqualsAndHashCode
+import org.gradle.api.Action
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
+import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor
+import org.gradle.api.credentials.Credentials
 import org.gradle.api.internal.artifacts.repositories.AuthenticationSupporter
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.tasks.Input
@@ -107,5 +110,15 @@ class DefaultNugetArtifactRepository implements NugetArtifactRepository {
     @Override
     void setName(String name) {
         this.name = name
+    }
+
+    @Override
+    void content(Action<? super RepositoryContentDescriptor> action) {
+
+    }
+
+    @Override
+    void credentials(Class<? extends Credentials> aClass) {
+
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepositoryHandlerConvention.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepositoryHandlerConvention.groovy
@@ -22,6 +22,8 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
 import org.gradle.api.internal.artifacts.DefaultArtifactRepositoryContainer
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.authentication.http.BasicAuthentication
 import org.gradle.internal.authentication.DefaultAuthenticationContainer
 import org.gradle.internal.authentication.DefaultBasicAuthentication
@@ -37,11 +39,15 @@ class DefaultNugetArtifactRepositoryHandlerConvention implements NugetRepository
     private final DefaultArtifactRepositoryContainer handler
     private final Instantiator instantiator
     private final FileResolver fileResolver
+    private final ObjectFactory objectFactory
+    private final ProviderFactory providerFactory
 
-    DefaultNugetArtifactRepositoryHandlerConvention(RepositoryHandler handler, FileResolver fileResolver, Instantiator instantiator) {
+    DefaultNugetArtifactRepositoryHandlerConvention(RepositoryHandler handler, FileResolver fileResolver, Instantiator instantiator, ObjectFactory objectFactory, ProviderFactory providerFactory) {
         this.handler = handler
         this.instantiator = instantiator
         this.fileResolver = fileResolver
+        this.objectFactory = objectFactory
+        this.providerFactory = providerFactory
     }
 
     @Override
@@ -60,7 +66,7 @@ class DefaultNugetArtifactRepositoryHandlerConvention implements NugetRepository
     }
 
     protected NugetArtifactRepository createNugetRepository() {
-        instantiator.newInstance(DefaultNugetArtifactRepository.class, fileResolver, instantiator, createAuthenticationContainer())
+        instantiator.newInstance(DefaultNugetArtifactRepository.class, fileResolver, instantiator, objectFactory, createAuthenticationContainer(), providerFactory)
     }
 
     protected AuthenticationContainer createAuthenticationContainer() {

--- a/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepositoryHandlerConvention.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/repository/internal/DefaultNugetArtifactRepositoryHandlerConvention.groovy
@@ -27,8 +27,10 @@ import org.gradle.internal.authentication.DefaultAuthenticationContainer
 import org.gradle.internal.authentication.DefaultBasicAuthentication
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.util.ConfigureUtil
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import wooga.gradle.paket.base.repository.NugetRepositoryHandlerConvention
 import wooga.gradle.paket.base.repository.NugetArtifactRepository
+
 
 class DefaultNugetArtifactRepositoryHandlerConvention implements NugetRepositoryHandlerConvention<NugetArtifactRepository> {
 
@@ -62,7 +64,7 @@ class DefaultNugetArtifactRepositoryHandlerConvention implements NugetRepository
     }
 
     protected AuthenticationContainer createAuthenticationContainer() {
-        DefaultAuthenticationContainer container = instantiator.newInstance(DefaultAuthenticationContainer.class, instantiator)
+        DefaultAuthenticationContainer container = instantiator.newInstance(DefaultAuthenticationContainer.class, instantiator, CollectionCallbackActionDecorator.NOOP)
 
         container.registerBinding(BasicAuthentication.class, DefaultBasicAuthentication.class)
         return container

--- a/src/main/groovy/wooga/gradle/paket/base/tasks/DownloadPaketBootstrapper.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/DownloadPaketBootstrapper.groovy
@@ -1,0 +1,37 @@
+package wooga.gradle.paket.base.tasks
+
+import org.gradle.api.GradleException
+import org.gradle.api.internal.ConventionTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+class DownloadPaketBootstrapper extends ConventionTask {
+    @Input
+    String bootstrapURL
+
+    @OutputFile
+    File paketBootstrapperExecutable
+
+    @TaskAction
+    protected void exec() {
+        File f = getPaketBootstrapperExecutable()
+        if (f.exists()) {
+            logger.info("Bootstrap file {} already exists", f.path)
+            return
+        }
+
+        f.parentFile.mkdirs()
+
+        def url =  new URL(getBootstrapURL())
+        url.withInputStream { i ->
+            f.withOutputStream {
+                it << i
+            }
+        }
+
+        if (!f.exists()) {
+            throw new GradleException("Failed to download bootstrapper from ${f.path}")
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/base/tasks/PaketBootstrap.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/PaketBootstrap.groovy
@@ -22,7 +22,9 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import wooga.gradle.paket.base.tasks.internal.AbstractPaketTask
@@ -44,16 +46,12 @@ import javax.inject.Inject
  * </pre>
  */
 class PaketBootstrap extends AbstractPaketTask {
-    static Logger logger = Logging.getLogger(PaketBootstrap)
-
-    @Input
-    String bootstrapURL
 
     @Optional
     @Input
     String paketVersion
 
-    @Input
+    @OutputFile
     File paketExecutable
 
     @OutputFiles
@@ -77,12 +75,6 @@ class PaketBootstrap extends AbstractPaketTask {
     }
 
     @Override
-    protected void performPaketCommand(IncrementalTaskInputs inputs) {
-        checkBootstrapper()
-        super.performPaketCommand(inputs)
-    }
-
-    @Override
     protected void configureArguments() {
         super.configureArguments()
         logger.info("requesting paket version: {}", getPaketVersion())
@@ -90,26 +82,5 @@ class PaketBootstrap extends AbstractPaketTask {
         args << getPaketVersion()
         args << "--prefer-nuget"
         args << "-v"
-    }
-
-    def checkBootstrapper() {
-        File f = getExecutable()
-        if (f.exists()) {
-            logger.info("Bootstrap file {} already exists", f.path)
-            return
-        }
-
-        f.parentFile.mkdirs()
-
-        def url =  new URL(getBootstrapURL())
-        url.withInputStream { i ->
-            f.withOutputStream {
-                it << i
-            }
-        }
-
-        if (!f.exists()) {
-            throw new GradleException("Failed to download bootstrapper from ${f.path}")
-        }
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/base/tasks/internal/AbstractPaketTask.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/internal/AbstractPaketTask.groovy
@@ -42,13 +42,17 @@ abstract class AbstractPaketTask<T extends AbstractPaketTask> extends Convention
     @Input
     String monoExecutable
 
+    private Object logFile
+
     @Optional
-    @InputFile
+    @OutputFile
     File getLogFile() {
         return logFile ? project.file(logFile) : null
     }
 
-    def logFile
+    void setLogFile(Object value) {
+        this.logFile = value
+    }
 
     @Optional
     @Input
@@ -69,6 +73,7 @@ abstract class AbstractPaketTask<T extends AbstractPaketTask> extends Convention
     /**
      * Returns the arguments for the command to be executed. Defaults to an empty list.
      */
+    @Input
     List<String> getArgs() {
         arguments
     }

--- a/src/main/groovy/wooga/gradle/paket/base/tasks/internal/AbstractPaketTask.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/internal/AbstractPaketTask.groovy
@@ -35,7 +35,7 @@ abstract class AbstractPaketTask<T extends AbstractPaketTask> extends Convention
     @Internal
     protected Boolean supportLogfile = true
 
-    @Input
+    @InputFile
     File executable
 
     @Optional
@@ -43,7 +43,7 @@ abstract class AbstractPaketTask<T extends AbstractPaketTask> extends Convention
     String monoExecutable
 
     @Optional
-    @Input
+    @InputFile
     File getLogFile() {
         return logFile ? project.file(logFile) : null
     }

--- a/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferences.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferences.groovy
@@ -30,7 +30,7 @@ class PaketUnityReferences {
         referencesContent.eachLine { line ->
 
             if(!line.empty){
-                nugets << line
+                nugets << line.trim()
             }
         }
     }

--- a/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/PaketPackPlugin.groovy
@@ -73,7 +73,7 @@ class PaketPackPlugin implements Plugin<Project> {
         final extension = project.extensions.create(EXTENSION_NAME, DefaultPaketPackPluginExtension, project, baseExtension.dependencyHandler)
 
         final configuration = project.configurations.getByName(PaketBasePlugin.PAKET_CONFIGURATION)
-        final templateFiles = project.fileTree(project.projectDir)
+        def templateFiles = project.fileTree(project.projectDir)
         templateFiles.include PAKET_TEMPLATE_PATTERN
         templateFiles = templateFiles.sort()
         templateFiles = templateFiles.sort(true, new Comparator<File>() {

--- a/src/main/groovy/wooga/gradle/paket/publish/repository/internal/NugetRepository.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/repository/internal/NugetRepository.groovy
@@ -17,6 +17,8 @@
 
 package wooga.gradle.paket.publish.repository.internal
 
+import org.gradle.api.Action
+import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor
 import wooga.gradle.paket.publish.repository.NugetArtifactRepository
 
 class NugetRepository implements NugetArtifactRepository {
@@ -59,5 +61,8 @@ class NugetRepository implements NugetArtifactRepository {
         path ? path : url
     }
 
+    @Override
+    void content(Action<? super RepositoryContentDescriptor> action) {
 
+    }
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -77,8 +77,8 @@ class PaketUnityPlugin implements Plugin<Project> {
             description = "Installs dependencies for all Unity3d projects"
         }
 
-        extension.paketReferencesFiles.each { referenceFile ->
-            def task = project.tasks.create(INSTALL_TASK_NAME + referenceFile.parentFile.name, PaketUnityInstall)
+        extension.paketReferencesFiles.files.each { referenceFile ->
+            def task = project.tasks.maybeCreate(INSTALL_TASK_NAME + referenceFile.parentFile.name, PaketUnityInstall)
             task.with {
                 group = GROUP
                 description = "Installs dependencies for Unity3d project ${referenceFile.parentFile.name} "
@@ -88,7 +88,7 @@ class PaketUnityPlugin implements Plugin<Project> {
                 frameworks = extension.getPaketDependencies().getFrameworks()
                 lockFile = extension.getPaketLockFile()
                 referencesFile = referenceFile
-                projectRoot = referenceFile.parentFile
+                //projectRoot = referenceFile.parentFile
             }
             lifecycleTask.dependsOn task
         }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -83,6 +83,7 @@ class PaketUnityPlugin implements Plugin<Project> {
                 group = GROUP
                 description = "Installs dependencies for Unity3d project ${referenceFile.parentFile.name} "
                 conventionMapping.map("paketOutputDirectoryName", { extension.getPaketOutputDirectoryName() })
+                conventionMapping.map("includeAssemblyDefinitions", { extension.getIncludeAssemblyDefinitions() })
                 conventionMapping.map("assemblyDefinitionFileStrategy", { extension.getAssemblyDefinitionFileStrategy() })
                 frameworks = extension.getPaketDependencies().getFrameworks()
                 lockFile = extension.getPaketLockFile()

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
@@ -55,4 +55,15 @@ interface PaketUnityPluginExtension extends PaketPluginExtension {
      * @param strategy the strategy to be used
      */
     void setAssemblyDefinitionFileStrategy(AssemblyDefinitionFileStrategy strategy)
+
+    /**
+     * Sets whether assembly definition files should be included during installation
+     * @param value
+     */
+    void setIncludeAssemblyDefinitions(Boolean value)
+
+    /**
+     * @return Whether assembly definition files should be included during installation
+     */
+    Boolean getIncludeAssemblyDefinitions()
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/AssemblyDefinitionFileStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/AssemblyDefinitionFileStrategy.groovy
@@ -19,4 +19,5 @@ package wooga.gradle.paket.unity.internal
 
 enum AssemblyDefinitionFileStrategy {
     manual, disabled
+
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -30,6 +30,8 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
     protected AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
     protected String customPaketOutputDirectory
+    protected Boolean includeAssemblyDefinitions
+
 
     DefaultPaketUnityPluginExtension(Project project,final PaketDependencyHandler dependencyHandler) {
         super(project, dependencyHandler)
@@ -59,5 +61,15 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
     @Override
     void setAssemblyDefinitionFileStrategy(AssemblyDefinitionFileStrategy strategy) {
         assemblyDefinitionFileStrategy = strategy
+    }
+
+    @Override
+    void setIncludeAssemblyDefinitions(Boolean value) {
+        includeAssemblyDefinitions = value
+    }
+
+    @Override
+    Boolean getIncludeAssemblyDefinitions() {
+        includeAssemblyDefinitions
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -30,8 +30,7 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
     protected AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
     protected String customPaketOutputDirectory
-    protected Boolean includeAssemblyDefinitions
-
+    protected Boolean includeAssemblyDefinitions = false
 
     DefaultPaketUnityPluginExtension(Project project,final PaketDependencyHandler dependencyHandler) {
         super(project, dependencyHandler)

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.paket.unity.tasks
 
+import groovy.transform.Internal
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Action
 import org.gradle.api.file.FileCollection
@@ -24,6 +25,7 @@ import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
@@ -87,8 +89,6 @@ class PaketUnityInstall extends ConventionTask {
     @Input
     AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
 
-    File projectRoot
-
     public final static String assemblyDefinitionFileExtension = "asmdef"
 
     /**
@@ -96,7 +96,7 @@ class PaketUnityInstall extends ConventionTask {
      */
     @OutputDirectory
     File getOutputDirectory() {
-        new File(getProjectRoot(), "Assets/${getPaketOutputDirectoryName()}")
+        new File(getReferencesFile().getParentFile(), "Assets/${getPaketOutputDirectoryName()}")
     }
 
     /**
@@ -161,10 +161,12 @@ class PaketUnityInstall extends ConventionTask {
         inputs.outOfDate(new Action<InputFileDetails>() {
             @Override
             void execute(InputFileDetails outOfDate) {
-                def outputPath = transformInputToOutputPath(outOfDate.file, project.file("packages"))
-                logger.info("${outOfDate.added ? "install" : "update"}: ${outputPath}")
-                FileUtils.copyFile(outOfDate.file, outputPath)
-                assert outputPath.exists()
+                if(inputFiles.contains(outOfDate.file)) {
+                    def outputPath = transformInputToOutputPath(outOfDate.file, project.file("packages"))
+                    logger.info("${outOfDate.added ? "install" : "update"}: ${outputPath}")
+                    FileUtils.copyFile(outOfDate.file, outputPath)
+                    assert outputPath.exists()
+                }
             }
         })
 

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -56,13 +57,13 @@ class PaketUnityInstall extends ConventionTask {
     /**
      * @return the path to a {@code paket.unity3d.references} file
      */
-    @Input
+    @InputFile
     File referencesFile
 
     /**
      * @return the path to a {@code paket.lock} file
      */
-    @Input
+    @InputFile
     File lockFile
 
     /**

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -77,10 +77,18 @@ class PaketUnityInstall extends ConventionTask {
     @Input
     String paketOutputDirectoryName
 
+    /**
+     * Whether assembly definition files (.asmdef) should be included during installation
+     */
+    @Input
+    Boolean includeAssemblyDefinitions = false
+
     @Input
     AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
 
     File projectRoot
+
+    public final static String assemblyDefinitionFileExtension = "asmdef"
 
     /**
      * @return the installation output directory
@@ -124,7 +132,13 @@ class PaketUnityInstall extends ConventionTask {
 
         fileTree.exclude("**/*.pdb")
         fileTree.exclude("**/Meta")
-        fileTree.files
+
+        if (!getIncludeAssemblyDefinitions()) {
+            fileTree.exclude("**/*.${assemblyDefinitionFileExtension}")
+        }
+
+        def files = fileTree.files
+        return files
     }
 
     PaketUnityInstall() {

--- a/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferencesSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketUnityReferencesSpec.groovy
@@ -1,0 +1,25 @@
+package wooga.gradle.paket.base.utils.internal
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+import wooga.gradle.paket.base.utils.internal.PaketTemplate
+
+class PaketUnityReferencesSpec extends Specification {
+
+    @Unroll
+    def "ensure items are trimmed"() {
+
+        when:
+        def refs = new PaketUnityReferences(content)
+
+        then:
+        refs.nugets == nugets
+
+        where:
+        content               | nugets
+        "A1\nA2\nA3\n"        | ["A1", "A2", "A3"]
+        " A1 \nA2\nA3\n"      | ["A1", "A2", "A3"]
+        " A1 \n A2 \nA3   \n" | ["A1", "A2", "A3"]
+    }
+}


### PR DESCRIPTION
## Description

This patch upgrades the whole plugin to be based on gradle 6.8.3. It will not be aimed to be backwards compatible with gradle older than version `5.0`.

## Changes

* ![UPDATE] ![GRADLE] to version `6.8.3`
* ![BREAK] ![GRADLE] supported backwards compatibility

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"