### PR TITLE
copy only first available framework

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
@@ -19,7 +19,7 @@ package wooga.gradle.paket
 
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.io.FileUtils
-import org.apache.commons.lang.StringEscapeUtils
+import org.apache.commons.lang3.StringEscapeUtils
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
 import spock.lang.Shared

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -125,8 +125,10 @@ class PaketUnityInstall extends ConventionTask {
         def fileTree = project.fileTree(dir: project.projectDir)
         fileTree.include("packages/${nuget}/content/**")
 
-        getFrameworks().each({
-            fileTree.include("packages/${nuget}/lib/${it}/**")
+        getFrameworks().find({
+            def exists = new File(project.projectDir, "packages/${nuget}/lib/${it}").exists()
+            if (exists) fileTree.include("packages/${nuget}/lib/${it}/**")
+            return exists
         })
 
         fileTree.include("packages/${nuget}/lib/*.dll")


### PR DESCRIPTION
## Description

Corner case (none we have)
framework: net35, netstandard2.0, net45
SDK.A  - net35, netstandard2.0
  dep.A - net35, net45
SDK.B  - netstandard2.0, net45
  dep.A - net35, netstandard2.0, net45

would select SDK.A  - net35, SDK.B - net45 and  dep.A - net35
while i would like it to select then all from netstandard2.0

## Changes
 



[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "WebGL"
[UNITY]:https://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[LINUX]:https://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"
