### PR TITLE
Updated atlas plugin to 2.2.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,12 +3,13 @@
 
 withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),
                  usernameColonPassword(credentialsId: 'artifactory_deploy', variable: 'artifactory_deploy'),
-                 string(credentialsId: 'atlas_paket_coveralls_token', variable: 'coveralls_token')]) {
+                 string(credentialsId: 'atlas_paket_coveralls_token', variable: 'coveralls_token'),
+                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
 
     def testEnvironment = [
                             "artifactoryCredentials=${artifactory_publish}",
                             "nugetkey=${artifactory_deploy}"
                           ]
 
-    buildGradlePlugin plaforms: ['osx','win','linux'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
+    buildGradlePlugin platforms: ['macos','windows','linux'], coverallsToken: coveralls_token, sonarToken: sonar_token, testEnvironment: testEnvironment
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id "net.wooga.plugins" version "2.0.0"
+    id "net.wooga.plugins" version "2.2.0"
 }
 
 group 'net.wooga.gradle'
@@ -68,6 +68,6 @@ dependencies {
     testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:2.+') {
         exclude module: 'logback-classic'
     }
-
+    testImplementation('org.apache.commons:commons-lang3:3.12.0')
     implementation('com.google.guava:guava:19.0')
 }

--- a/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/IntegrationSpec.groovy
@@ -19,7 +19,7 @@ package wooga.gradle.paket
 
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.io.FileUtils
-import org.apache.commons.lang.StringEscapeUtils
+import org.apache.commons.lang3.StringEscapeUtils
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
 import spock.lang.Shared


### PR DESCRIPTION
## Description
atlas plugin gradle plugin updated to 2.2.0, and added Sonarqube support on Jenkinsfile.

## Changes
* ![UPDATE] `atlas-plugin` gradle plugin to `2.2.0`
* ![NEW] Sonarqube project being uploaded on Jenkinsfile execution



[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"