### PR TITLE
Add snyk integration [ATLAS-701]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,8 @@
 withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', variable: 'artifactory_publish'),
                  usernameColonPassword(credentialsId: 'artifactory_deploy', variable: 'artifactory_deploy'),
                  string(credentialsId: 'atlas_paket_coveralls_token', variable: 'coveralls_token'),
-                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
+                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
+                 string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')]) {
 
     def testEnvironment = [
                             "artifactoryCredentials=${artifactory_publish}",

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,10 @@
  */
 
 plugins {
-    id "net.wooga.plugins" version "2.2.0"
+    id "net.wooga.plugins" version "2.3.0"
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-gradle-plugin" version "0.2.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
 group 'net.wooga.gradle'
@@ -64,10 +67,15 @@ github {
     repositoryName = "wooga/atlas-paket"
 }
 
+cveHandler {
+    configurations("compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath", "integrationTestCompileClasspath", "integrationTestRuntimeClasspath")
+}
+
 dependencies {
-    testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:2.+') {
+    testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:[2,3[') {
         exclude module: 'logback-classic'
     }
     testImplementation('org.apache.commons:commons-lang3:3.12.0')
+    testImplementation 'org.apache.httpcomponents:httpclient:[4.5.13,5)'
     implementation('com.google.guava:guava:19.0')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,5 +21,11 @@ include 'shared'
 include 'api'
 include 'services:webservice'
 */
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
 
 rootProject.name = 'atlas-paket'

--- a/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/PaketIntegrationBaseSpec.groovy
@@ -33,6 +33,14 @@ abstract class PaketIntegrationBaseSpec extends IntegrationSpec {
     @Shared
     String bootstrapperFileName = "paket.bootstrapper.exe"
 
+    def setPaketVersion(String version = "5.219.0") {
+        buildFile << """
+        paketBootstrap {
+           paketVersion = "${version}"
+        } 
+        """.stripIndent()
+    }
+
     @Unroll
     def "calls paketBootstrap when running #taskToRun"(String taskToRun) {
         given: "an empty paket dependency and lock file"

--- a/src/integrationTest/groovy/wooga/gradle/paket/base/PaketBaseIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/base/PaketBaseIntegrationSpec.groovy
@@ -34,6 +34,8 @@ class PaketBaseIntegrationSpec extends PaketIntegrationBaseSpec {
             group = 'test'
             ${applyPlugin(PaketGetPlugin)}
         """.stripIndent()
+
+        setPaketVersion()
     }
 
     @Override

--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
@@ -28,6 +28,7 @@ class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
             group = 'test'
             ${applyPlugin(PaketGetPlugin)}
         """.stripIndent()
+        setPaketVersion()
     }
 
     @Override

--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketRestoreIntegrationSpec.groovy
@@ -29,6 +29,7 @@ class PaketRestoreIntegrationSpec extends PaketIntegrationBaseSpec {
             group = 'test'
             ${applyPlugin(PaketGetPlugin)}
         """.stripIndent()
+        setPaketVersion()
     }
 
     @Override

--- a/src/integrationTest/groovy/wooga/gradle/paket/pack/PaketPackIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/pack/PaketPackIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class PaketPackIntegrationSpec extends PaketIntegrationDependencyFileSpec {
             version = "$version"
             ${applyPlugin(PaketPackPlugin)}
         """.stripIndent()
-
+        setPaketVersion()
         paketTemplateFile = createFile("paket.template")
         paketTemplateFile << """
             type file
@@ -104,6 +104,7 @@ class PaketPackIntegrationSpec extends PaketIntegrationDependencyFileSpec {
             ${applyPlugin(PaketPackPlugin)}
             version = "$version"
         """.stripIndent()
+        setPaketVersion()
 
         and: "a future output file"
         def outputFile = new File(new File(new File(projectDir, 'build'), "outputs"), "${packageID}.${version}.nupkg")
@@ -132,6 +133,7 @@ class PaketPackIntegrationSpec extends PaketIntegrationDependencyFileSpec {
             ${applyPlugin(PaketPackPlugin)}
             version = "0.0.0"
         """.stripIndent()
+        setPaketVersion()
 
         and: "a custom template file with version"
         paketTemplateFile.text = ""
@@ -174,6 +176,7 @@ class PaketPackIntegrationSpec extends PaketIntegrationDependencyFileSpec {
             ${applyPlugin(PaketPackPlugin)}
             version = "$version"
         """.stripIndent()
+        setPaketVersion()
 
         and: "a custom template file without version"
         paketTemplateFile.text = ""
@@ -228,6 +231,7 @@ class PaketPackIntegrationSpec extends PaketIntegrationDependencyFileSpec {
                 version = {"$version"}
             }
         """.stripIndent()
+        setPaketVersion()
 
 
         and: "a future output file"
@@ -256,6 +260,7 @@ class PaketPackIntegrationSpec extends PaketIntegrationDependencyFileSpec {
             group = 'test'
             ${applyPlugin(PaketPackPlugin)}
         """.stripIndent()
+        setPaketVersion()
 
         and: "a custom template file without version"
         paketTemplateFile.text = ""
@@ -297,6 +302,7 @@ class PaketPackIntegrationSpec extends PaketIntegrationDependencyFileSpec {
             ${applyPlugin(PaketPackPlugin)}
             version = "0.0.0"
         """.stripIndent()
+        setPaketVersion()
 
         and: "a custom template file with version"
         paketTemplateFile.text = ""

--- a/src/integrationTest/groovy/wooga/gradle/paket/publish/PaketPublishIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/publish/PaketPublishIntegrationSpec.groovy
@@ -103,7 +103,7 @@ class PaketPublishIntegrationSpec extends PaketIntegrationDependencyFileSpec {
             }
 
         """.stripIndent()
-
+        setPaketVersion()
         paketTemplateFile = createFile("paket.template")
         paketTemplateFile << """
             type file
@@ -201,6 +201,7 @@ class PaketPublishIntegrationSpec extends PaketIntegrationDependencyFileSpec {
                 publishRepositoryName = "$repoName"
             }
         """.stripIndent()
+        setPaketVersion()
 
         when: "run the publish task"
         def result = runTasks("publish")
@@ -247,6 +248,7 @@ class PaketPublishIntegrationSpec extends PaketIntegrationDependencyFileSpec {
             }
 
         """.stripIndent()
+        setPaketVersion()
 
         and: "a future local output file"
         def futureFile = new File(escapedPath, nugetArtifact.name)

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -91,8 +91,6 @@ class PaketUnityInstall extends ConventionTask {
 
     public final static String assemblyDefinitionFileExtension = "asmdef"
 
-    public final static String assemblyDefinitionFileExtension = "asmdef"
-
     /**
      * @return the installation output directory
      */


### PR DESCRIPTION
## Decription

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin net.wooga.cve-dependency-resolution which applies overrides for dependencies with know fixes for security issues.

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
