### PR TITLE
Fix the issue when switching includeAssemblyDefinitions

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/get/PaketInstallIntegrationSpec.groovy
@@ -130,7 +130,8 @@ class PaketInstallIntegrationSpec extends PaketIntegrationDependencyFileSpec {
         result.standardOutput.contains("Update $nuget to their latest version and update projects.")
     }
 
-    //generated dependencies update task updates only one dependency
+    // generated dependencies update task updates only one dependency
+    // The test name is written in shorthand due to the default path character limit (260) on Windows
     def "gdutuood"() {
         given: "A few small test nugets"
         def nuget1 = "Mini"

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -30,8 +30,6 @@ import wooga.gradle.paket.unity.internal.DefaultPaketUnityPluginExtension
 import wooga.gradle.paket.unity.tasks.PaketUnityInstall
 import wooga.gradle.paket.unity.tasks.PaketUnwrapUPMPackages
 
-import java.util.stream.Collectors
-
 /**
  * A {@link Plugin} which adds tasks to install NuGet packages into a Unity3D project.
  * <p>
@@ -62,7 +60,7 @@ class PaketUnityPlugin implements Plugin<Project> {
         final extension = project.extensions.create(EXTENSION_NAME, DefaultPaketUnityPluginExtension, project, baseExtension.dependencyHandler)
         createPaketUnityInstallTasks(project, extension)
         createPaketUpmUnwrapTasks(project, extension)
-        extension.assemblyDefinitionFileStrategy = AssemblyDefinitionFileStrategy.manual
+        extension.assemblyDefinitionFileStrategy = PaketUnityPluginConventions.assemblyDefinitionFileStrategy
 
         project.tasks.matching({ it.name.startsWith("paketUnity")}).configureEach { task ->
             task.onlyIf {

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginConventions.groovy
@@ -1,0 +1,7 @@
+package wooga.gradle.paket.unity
+
+import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
+
+class PaketUnityPluginConventions {
+     static final AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy = AssemblyDefinitionFileStrategy.disabled
+}

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/AssemblyDefinitionFileStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/AssemblyDefinitionFileStrategy.groovy
@@ -17,7 +17,17 @@
 
 package wooga.gradle.paket.unity.internal
 
+/**
+ * The strategy to employ regarding assembly definition files
+ */
 enum AssemblyDefinitionFileStrategy {
-    manual, disabled
 
+    /**
+     * Assembly definition files will be manually handled by the user
+     */
+    manual,
+    /**
+     * The default behavior, treat them as any other file
+     */
+    disabled
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -34,6 +34,7 @@ import wooga.gradle.paket.base.utils.internal.PaketLock
 import wooga.gradle.paket.base.utils.internal.PaketUnityReferences
 import wooga.gradle.paket.unity.PaketUnityPlugin
 import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
+
 /**
  * A task to copy referenced NuGet packages into Unity3D projects.
  * <p>
@@ -42,13 +43,11 @@ import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
  * Example:
  * <pre>
  * {@code
- *     task unityInstall(type:wooga.gradle.paket.unity.tasks.PaketUnityInstall) {
- *         referencesFile = file('paket.unity3D.references')
+ *     task unityInstall(type:wooga.gradle.paket.unity.tasks.PaketUnityInstall) {*         referencesFile = file('paket.unity3D.references')
  *         lockFile = file('../paket.lock')
  *         frameworks = ["net11", "net20", "net35"]
  *         paketOutputDirectoryName = "PaketUnity3D"
- *     }
- * }
+ *}*}
  * </pre>
  */
 class PaketUnityInstall extends ConventionTask {
@@ -120,6 +119,15 @@ class PaketUnityInstall extends ConventionTask {
         project.files(files)
     }
 
+    PaketUnityInstall() {
+        description = 'Copy paket dependencies into unity projects'
+        group = PaketUnityPlugin.GROUP
+    }
+
+    /**
+     * @param nuget The name of the package
+     * @return The files to be copied over from this package
+     */
     Set<File> getFilesForPackage(String nuget) {
         def fileTree = project.fileTree(dir: project.projectDir)
         fileTree.include("packages/${nuget}/content/**")
@@ -141,11 +149,6 @@ class PaketUnityInstall extends ConventionTask {
         return files
     }
 
-    PaketUnityInstall() {
-        description = 'Copy paket dependencies into unity projects'
-        group = PaketUnityPlugin.GROUP
-    }
-
     @TaskAction
     protected performCopy(IncrementalTaskInputs inputs) {
 
@@ -160,7 +163,7 @@ class PaketUnityInstall extends ConventionTask {
         inputs.outOfDate(new Action<InputFileDetails>() {
             @Override
             void execute(InputFileDetails outOfDate) {
-                if(inputFiles.contains(outOfDate.file)) {
+                if (inputFiles.contains(outOfDate.file)) {
                     def outputPath = transformInputToOutputPath(outOfDate.file, project.file("packages"))
                     logger.info("${outOfDate.added ? "install" : "update"}: ${outputPath}")
                     FileUtils.copyFile(outOfDate.file, outputPath)
@@ -193,7 +196,8 @@ class PaketUnityInstall extends ConventionTask {
     protected void cleanOutputDirectory() {
         def tree = project.fileTree(getOutputDirectory())
 
-        if(getAssemblyDefinitionFileStrategy() == AssemblyDefinitionFileStrategy.manual) {
+        // If the strategy is manual, do not delete asmdefs
+        if (getAssemblyDefinitionFileStrategy() == AssemblyDefinitionFileStrategy.manual) {
             tree.exclude("**/*.asmdef")
             tree.exclude("**/*.asmdef.meta")
         }


### PR DESCRIPTION
## Description
When one initially includes assembly definitions but then disables it and runs `paketInstall`, the cache won't be updated properly, thus the assembly definitions won't be removed when they should be.

The issue ended up being due to the `AssemblyDefinitionFileStrategy` being set to `manual`, which made the asmdef files being ignored during the output directory cleanup (thus not deleted). Instead it has been set to `disabled`, leading to expected behaviour.

## Changes
* ![FIX] `includeAssemblyDefinitions` up-to-date check, by disabling the assembly file definition strategy

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
