### PR TITLE
Improve paket-unity install filter for assembly definition files

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
@@ -202,7 +202,7 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
         result.wasExecuted(PaketUnityPlugin.UNWRAP_UPM_TASK_NAME)
     }
 
-    @Unroll("Copy assembly definitions when includeAssemblyDefinitions is #includeAssemblyDefinitions and set in #configurationString")
+    @Unroll("#message assembly definitions when includeAssemblyDefinitions is #includeAssemblyDefinitions and set in #configurationString")
     def "copy assembly definition files"() {
 
         given: "apply paket get plugin to get paket install task"
@@ -221,8 +221,12 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
 
         and: "setup assembly definition file in package"
         def asmdefFileName = "${dependencyName}.${PaketUnityInstall.assemblyDefinitionFileExtension}"
+        def asmdefRefName = "${dependencyName}.${PaketUnityInstall.assemblyReferenceFileExtension}"
+
         def inputAsmdefFile = createFile("packages/${dependencyName}/content/${asmdefFileName}")
+        def inputAsmRefFile = createFile("packages/${dependencyName}/content/${asmdefRefName}")
         assert inputAsmdefFile.exists()
+        assert inputAsmRefFile.exists()
 
         when:
         def result = runTasksSuccessfully(PaketUnityPlugin.INSTALL_TASK_NAME)
@@ -232,9 +236,10 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
 
         then:
         result.wasExecuted(PaketUnityPlugin.INSTALL_TASK_NAME)
-        def outputAsmdefFilePath = "${packagesDir}/${asmdefFileName}"
-        def outputAsmdefFile = new File(outputAsmdefFilePath)
+        def outputAsmdefFile = new File("${packagesDir}/${asmdefFileName}")
+        def outputAsmRefFile = new File("${packagesDir}/${asmdefRefName}")
         includeAssemblyDefinitions == outputAsmdefFile.exists()
+        includeAssemblyDefinitions == outputAsmRefFile.exists()
 
         where:
         baseConfigurationString | includeAssemblyDefinitions
@@ -247,6 +252,7 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
         taskName = PaketUnityPlugin.INSTALL_TASK_NAME + unityProjectName
         dependencyName = "Wooga.TestDependency"
         configurationString = baseConfigurationString.replace("#taskName%%", "'${taskName}'")
+        message = includeAssemblyDefinitions ? "Skip copy" : "copy"
     }
 
     private void setupPaketProject(dependencyName, unityProjectName) {

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -86,6 +86,7 @@ class PaketUnityInstall extends ConventionTask {
     AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
 
     public final static String assemblyDefinitionFileExtension = "asmdef"
+    public final static String assemblyReferenceFileExtension = "asmref"
 
     /**
      * @return the installation output directory
@@ -143,6 +144,9 @@ class PaketUnityInstall extends ConventionTask {
 
         if (!getIncludeAssemblyDefinitions()) {
             fileTree.exclude("**/*.${assemblyDefinitionFileExtension}")
+            fileTree.exclude("**/*.${assemblyDefinitionFileExtension}.meta")
+            fileTree.exclude("**/*.${assemblyReferenceFileExtension}")
+            fileTree.exclude("**/*.${assemblyReferenceFileExtension}.meta")
         }
 
         def files = fileTree.files


### PR DESCRIPTION
## Description

The install filter for `includeAssemblyDefinitions` in the `net.wooga.paket-unity` plugin doesn't filter out all content. I adjusted the filter to also be awar of `.asmref` files and the `asmdef.meta` as well as `.asmref.meta`.

This is just cosmetic patch since these files do now harm if present.

## Changes

* ![IMPROVE] `net.wooga.paket-unity` assembly definition file filter

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
