### PR TITLE
Add paket-unity UPM mode [ATLAS-1273]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,5 +11,5 @@ withCredentials([usernameColonPassword(credentialsId: 'artifactory_publish', var
                             "nugetkey=${artifactory_deploy}"
                           ]
 
-    buildGradlePlugin platforms: ['macos','windows','linux'], sonarToken: sonar_token, testEnvironment: testEnvironment
+    buildGradlePlugin platforms: ['macos','windows'/*,'linux'*/], sonarToken: sonar_token, testEnvironment: testEnvironment
 }

--- a/build.gradle
+++ b/build.gradle
@@ -102,4 +102,6 @@ dependencies {
     testImplementation('org.apache.commons:commons-lang3:3.12.0')
     testImplementation 'org.apache.httpcomponents:httpclient:[4.5.13,5)'
     implementation('com.google.guava:guava:19.0')
+    implementation 'com.wooga.gradle:gradle-commons:[1,2['
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['
 }

--- a/docs/Unity.md
+++ b/docs/Unity.md
@@ -8,10 +8,45 @@ Tasks
 
 The `paket-unity` plugin adds a few tasks that will hook themself onto `paket-get`
 
-| Task name           | Depends on          | Type                                                | Description |
-| ------------------- | ------------------- | --------------------------------------------------- | ----------- |
-| paketUnityInstall   | | `wooga.gradle.paket.unity.tasks.PaketUnityInstall`  | Installs the dependencies into the Unity3d project
+| Task name         | Depends on | Type                                               | Description                                        |
+|-------------------|------------|----------------------------------------------------|----------------------------------------------------|
+| paketUnityInstall |            | `wooga.gradle.paket.unity.tasks.PaketUnityInstall` | Installs the dependencies into the Unity3d project |
 
-The `paketUnityInstall` will configure itself as a [`finalizedBy`][gradle_finalizedBy] task for `paketInstall`, `paketRestore` and `paketUpdate`. There is no need to call this task manually. The task also gets skipped when no `paket.unity3d.references` file can be found anywhere in the project directory tree.
+The `paketUnityInstall` will configure itself as a [`finalizedBy`][gradle_finalizedBy] task
+for `paketInstall`, `paketRestore` and `paketUpdate`. There is no need to call this task manually. The task also gets
+skipped when no `paket.unity3d.references` file can be found anywhere in the project directory tree.
+
+
+Extension
+---------
+
+The `paketUnity` extension provided by the plugin can be used for configuration. It has all properties
+from `PaketPluginExtension`, plus the ones below:
+
+| Property                       | Type                                    | Description                                                                                     |
+|--------------------------------|-----------------------------------------|-------------------------------------------------------------------------------------------------|
+| paketReferenceFiles            | `FileCollection` (Read only)            | A list of all `paket.unity3D.references` files                                                  |
+| paketOutputDirectoryName       | `String`                                | Output directory for the paket installation. Relative to `<unity_project>/Assets`.              |
+| assemblyDefinitionFileStrategy | `AssemblyDefinitionFileStrategy` (Enum) | Strategy regarding assemble definition files.                                                   |
+| includeAssemblyDefinitions     | `Boolean`                               | Whether assembly definition files should be included during installation.                       |
+| paketUpmPackageEnabled         | `Property<Boolean>`                     | Enables/Disables UPM package mode.                                                              |
+| paketUpmPackageManifests       | `MapProperty<String, Map>`              | Maps `[paketName: upmPackageManifestMap]` for package.json files generated in UPM package mode. |
+
+
+UPM mode
+--------
+
+Paket packages can also be configured to be installed as UPM packages. This can be useful when your paket package
+contains an UPM one (with a `package.json` file).
+This mode sets the installation directory (`paketOutputDirectoryName`) to the unity project's `Packages` folder, and
+ensures that the `package.json`
+file for each dependency is in the installed package root.
+
+If an installed package is not UPM-compatible, that is, it doesn't have a `package.json` file, such file will be created. 
+By default, a `package.json` is generated with `com.wooga.nuget.${paketPackage.toLowerCase()}` name, and version `0.0.0`, 
+but those can be overridden and more properties can be added on using the mappings in `paketUpmPacakgeJson`. 
+
+UPM mode can be enabled through the `paketUpmPackageEnabled` property, or using the `paketUnity.enablePaketUpmPackages()` extension
+method. It is disabled by default.
 
 [gradle_finalizedBy]:   https://docs.gradle.org/3.5/dsl/org.gradle.api.Task.html#org.gradle.api.Task:finalizedBy

--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
@@ -27,7 +27,6 @@ import wooga.gradle.extensions.PaketDependencyInterceptor
 import wooga.gradle.paket.get.PaketGetPlugin
 import wooga.gradle.paket.unity.fixtures.PaketFixturesTrait
 import wooga.gradle.paket.unity.tasks.PaketUnityInstall
-import wooga.gradle.paket.unity.tasks.PaketUnwrapUPMPackages
 
 class PaketUnityIntegrationSpec extends IntegrationSpec implements PaketFixturesTrait {
 
@@ -294,7 +293,7 @@ class PaketUnityIntegrationSpec extends IntegrationSpec implements PaketFixtures
             paketUnity {
                 paketUpmPackageEnabled = $paketUpmPackageEnabled
                 ${overrides ?
-                "paketUpmPackageJson = ['test': ${PropertyUtils.wrapValueBasedOnType(overrides, Map)}]" :
+                "paketUpmPackageManifests = ['test': ${PropertyUtils.wrapValueBasedOnType(overrides, Map)}]" :
                 ""
         }
             }
@@ -306,23 +305,23 @@ class PaketUnityIntegrationSpec extends IntegrationSpec implements PaketFixtures
         then:
         result.success
         def pkgJsonFile = new File(pktUnityInstallDir, "package.json")
-        if (hasPackageJson) {
+        if (hasPackageManifest) {
             pkgJsonFile.file
             manifestJson.file
             def pkgJson = new JsonSlurper().parse(pkgJsonFile) as Map<String, Object>
             pkgJson['name'] == (overrides?.get('name') ?: "com.wooga.nuget.${pktUnityInstallDir.name.toLowerCase()}")
-            pkgJson.entrySet().containsAll(overrides?.entrySet()?: [:])
+            pkgJson.entrySet().containsAll(overrides?.entrySet() ?: [:])
         } else {
             !pkgJsonFile.file
             !manifestJson.file
         }
 
         where:
-        paketUpmPackageEnabled | hasPackageJson | overrides                 | msg
-        true                   | true           | null                      | "has"
-        true                   | true           | [name: "com.custom.name"] | "has"
-        true                   | true           | [custom: "customfield"]   | "has"
-        false                  | false          | null                      | "hasn't"
+        paketUpmPackageEnabled | hasPackageManifest | overrides                 | msg
+        true                   | true               | null                      | "has"
+        true                   | true               | [name: "com.custom.name"] | "has"
+        true                   | true               | [custom: "customfield"]   | "has"
+        false                  | false              | null                      | "hasn't"
     }
 
     private void setupPaketProject(dependencyName, unityProjectName) {

--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityIntegrationSpec.groovy
@@ -17,16 +17,18 @@
 
 package wooga.gradle.paket.unity
 
+import groovy.json.JsonSlurper
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.extensions.PaketDependencyInterceptor
 import wooga.gradle.paket.get.PaketGetPlugin
+import wooga.gradle.paket.unity.fixtures.PaketFixturesTrait
 import wooga.gradle.paket.unity.tasks.PaketUnityInstall
 import wooga.gradle.paket.unity.tasks.PaketUnwrapUPMPackages
 
-class PaketUnityIntegrationSpec extends IntegrationSpec {
+class PaketUnityIntegrationSpec extends IntegrationSpec implements PaketFixturesTrait {
 
     def setup() {
         buildFile << """
@@ -237,9 +239,9 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
         includeAssemblyDefinitions == outputAsmdefFile.exists()
 
         where:
-        baseConfigurationString | includeAssemblyDefinitions
-        "paketUnity" | true
-        "paketUnity" | false
+        baseConfigurationString                | includeAssemblyDefinitions
+        "paketUnity"                           | true
+        "paketUnity"                           | false
         "project.tasks.getByName(#taskName%%)" | true
         "project.tasks.getByName(#taskName%%)" | false
 
@@ -247,6 +249,78 @@ class PaketUnityIntegrationSpec extends IntegrationSpec {
         taskName = PaketUnityPlugin.INSTALL_TASK_NAME + unityProjectName
         dependencyName = "Wooga.TestDependency"
         configurationString = baseConfigurationString.replace("#taskName%%", "'${taskName}'")
+    }
+
+    def "ensures Paket-installed UPM packages have the package dot json in the package root"() {
+        given:
+        def unityProjDir = new File(projectDir, "unity")
+        new File(unityProjDir, "Assets").mkdirs()
+        def (_, testPkgJson) = fakeUPMPaketPackage("test", unityProjDir)
+        def pkgInstallDir = new File(unityProjDir, "Packages/test")
+        def testPkgContents = testPkgJson.text
+
+        and:
+        buildFile << """
+            paketUnity {
+                enablePaketUpmPackages()
+            }
+        """
+
+        when:
+        def result = runTasks(PaketUnityPlugin.INSTALL_TASK_NAME)
+
+        then:
+        result.success
+        def pkgJsonFile = new File(pkgInstallDir, "package.json")
+        pkgJsonFile.file
+        pkgJsonFile.text == testPkgContents
+    }
+
+    def "ensures Paket-installed non-UPM packages #msg a generated package dot json in package root when paketUpmPackageEnabled is #paketUpmPackageEnabled"() {
+        given:
+        def unityProjDir = new File(projectDir, "unity")
+        new File(unityProjDir, "Assets").mkdirs()
+        def testNuGetPackage = fakePaketPackage("test")
+        def manifestJson = new File(unityProjDir, "Packages/manifest.json").with {
+            mkdirs(); createNewFile();
+            it
+        }
+        def pktUnityInstallDir = new File(unityProjDir, "Packages/test")
+        assert !new File(testNuGetPackage, "package.json").exists()
+
+        and:
+        buildFile << """
+            paketUnity {
+                paketUpmPackageEnabled = $paketUpmPackageEnabled
+                ${expectedName ?
+                "paketUpmPackageNames = ['test': '${expectedName}']" :
+                ""
+        }
+            }
+        """
+
+        when:
+        def result = runTasks(PaketUnityPlugin.INSTALL_TASK_NAME)
+
+        then:
+        result.success
+        def pkgJsonFile = new File(pktUnityInstallDir, "package.json")
+        if (hasPackageJson) {
+            pkgJsonFile.file
+            manifestJson.file
+            def pkgJson = new JsonSlurper().parse(pkgJsonFile)
+            pkgJson['name'] == (expectedName ?: "com.wooga.nuget.${pktUnityInstallDir.name.toLowerCase()}")
+            pkgJson['version'] == "0.0.0"
+        } else {
+            !pkgJsonFile.file
+            !manifestJson.file
+        }
+
+        where:
+        paketUpmPackageEnabled | hasPackageJson | expectedName      | msg
+        true                   | true           | null              | "has"
+        true                   | true           | "com.custom.name" | "has"
+        false                  | false          | null              | "hasn't"
     }
 
     private void setupPaketProject(dependencyName, unityProjectName) {

--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/fixtures/PaketFixtures.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/fixtures/PaketFixtures.groovy
@@ -1,0 +1,76 @@
+package wooga.gradle.paket.unity.fixtures
+
+import nebula.test.IntegrationSpec
+
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.stream.Collectors
+
+class PaketFixtures implements PaketFixturesTrait {
+
+    private IntegrationSpec spec
+
+    PaketFixtures(IntegrationSpec spec) {
+        this.spec = spec
+    }
+
+    @Override
+    File getProjectDir() {
+        return spec.projectDir
+    }
+}
+
+trait PaketFixturesTrait {
+    abstract File getProjectDir()
+
+    File fakePaketPackage(String name,
+                          File baseDir = projectDir,
+                          File installedPackagesDir = new File(projectDir, "packages"),
+                          File unityDir = new File(projectDir, "unity")) {
+        def dependencies = new File(projectDir, "paket.dependencies")
+        dependencies << """
+        source https://nuget.org/api/v2
+        nuget ${name}
+          """.stripIndent()
+
+        def lockFile = new File(projectDir, "paket.lock")
+        lockFile << """${name}""".stripIndent().trim()
+
+        def referencesFile = new File(unityDir, "paket.unity3d.references")
+        referencesFile.parentFile.mkdirs()
+        referencesFile << "\n${name}".stripIndent().trim()
+
+        def packageFolder = new File(installedPackagesDir, "$name")
+        packageFolder.mkdirs()
+        packageFolder.with {
+            new File(it, "content/innerFolder").mkdirs()
+            new File(it, "content/innerFolder/something.cs") << "CONTENT"
+        }
+        return packageFolder
+    }
+
+    Tuple2<File, File> fakeUPMPaketPackage(String name,
+                                           File unityDir = new File(projectDir, "unity"),
+                                           File installedPackagesDir = new File(projectDir, "packages"),
+                                           File baseDir = projectDir) {
+        def packageFolder = fakePaketPackage(name, baseDir, installedPackagesDir, unityDir)
+        createMetafiles(packageFolder)
+        new File(packageFolder, "content/innerFolder/package.json") << """{"name" : "com.something.${name.toLowerCase()}"}"""
+        new File(packageFolder, "content/innerFolder/package.json.meta") << "META"
+        return [packageFolder, new File(packageFolder, "content/innerFolder/package.json")]
+    }
+
+    List<File> createMetafiles(File baseFolder) {
+        def metaCandidates = Files.walk(baseFolder.toPath()).map {it.toFile() }
+            .filter { it != baseFolder }
+            .filter {!it.name.endsWith(".meta") }
+
+        def createdMetas = metaCandidates.map { new File(it.parentFile, "${it.name}.meta") }
+            .filter {!it.exists() }
+            .map {it << "META" }
+            .collect(Collectors.toList())
+
+        return createdMetas
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -61,6 +61,7 @@ class PaketUnityPlugin implements Plugin<Project> {
         createPaketUnityInstallTasks(project, extension)
         createPaketUpmUnwrapTasks(project, extension)
         extension.assemblyDefinitionFileStrategy = PaketUnityPluginConventions.assemblyDefinitionFileStrategy
+        extension.paketUpmPackageEnabled.convention(PaketUnityPluginConventions.paketUpmPackageEnabled)
 
         project.tasks.matching({ it.name.startsWith("paketUnity")}).configureEach { task ->
             task.onlyIf {
@@ -86,6 +87,8 @@ class PaketUnityPlugin implements Plugin<Project> {
                 t.frameworks = extension.getPaketDependencies().getFrameworks()
                 t.lockFile = extension.getPaketLockFile()
                 t.referencesFile = referenceFile
+                t.paketUpmPackageEnabled.convention(extension.paketUpmPackageEnabled)
+                t.paketUpmPackageNames.convention(extension.paketUpmPackageNames)
             }
             return installProvider
         }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -86,7 +86,7 @@ class PaketUnityPlugin implements Plugin<Project> {
                 t.lockFile = extension.getPaketLockFile()
                 t.referencesFile = referenceFile
                 t.paketUpmPackageEnabled.convention(extension.paketUpmPackageEnabled)
-                t.paketUpmPackageJson.convention(extension.paketUpmPackageJson)
+                t.paketUpmPackageManifests.convention(extension.paketUpmPackageManifests)
             }
             return installProvider
         }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -17,15 +17,13 @@
 
 package wooga.gradle.paket.unity
 
-import org.gradle.api.Action
+
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.file.CopySpec
 import wooga.gradle.paket.base.PaketBasePlugin
 import wooga.gradle.paket.base.PaketPluginExtension
 import wooga.gradle.paket.get.PaketGetPlugin
 import wooga.gradle.paket.get.tasks.PaketUpdate
-import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
 import wooga.gradle.paket.unity.internal.DefaultPaketUnityPluginExtension
 import wooga.gradle.paket.unity.tasks.PaketUnityInstall
 import wooga.gradle.paket.unity.tasks.PaketUnwrapUPMPackages
@@ -88,7 +86,7 @@ class PaketUnityPlugin implements Plugin<Project> {
                 t.lockFile = extension.getPaketLockFile()
                 t.referencesFile = referenceFile
                 t.paketUpmPackageEnabled.convention(extension.paketUpmPackageEnabled)
-                t.paketUpmPackageNames.convention(extension.paketUpmPackageNames)
+                t.paketUpmPackageJson.convention(extension.paketUpmPackageJson)
             }
             return installProvider
         }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginConventions.groovy
@@ -4,4 +4,5 @@ import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
 
 class PaketUnityPluginConventions {
      static final AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy = AssemblyDefinitionFileStrategy.disabled
+     static final boolean paketUpmPackageEnabled = false
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
@@ -34,7 +34,7 @@ interface PaketUnityPluginExtension extends PaketPluginExtension, PaketUpmPackag
     FileCollection getPaketReferencesFiles()
 
     /**
-     * @return  the paket unity output directory name
+     * @return  the paket unity output directory name. Relative to `<unity_project>/Assets`
      */
     String getPaketOutputDirectoryName()
 

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
@@ -24,7 +24,7 @@ import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
 /**
  * A extensions point for paket unity
  */
-interface PaketUnityPluginExtension extends PaketPluginExtension {
+interface PaketUnityPluginExtension extends PaketPluginExtension, PaketUpmPackageSpec {
 
     /**
      * Returns a {@link FileCollection} object containing all {@code paket.unity3D.references} files.

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUpmPackageSpec.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUpmPackageSpec.groovy
@@ -9,28 +9,23 @@ import org.gradle.api.tasks.Optional
 
 trait PaketUpmPackageSpec implements BaseSpec {
 
-    private final MapProperty<String, String> paketUpmPackageNames = objects.mapProperty(String, String)
+    /**
+     *
+     */
+    private final MapProperty<String, Map<String, Object>> paketUpmPackageJson = objects.mapProperty(String, Map)
 
     @Input
     @Optional
-    MapProperty<String, String> getPaketUpmPackageNames() {
-        return paketUpmPackageNames
+    MapProperty<String, Map<String, Object>> getPaketUpmPackageJson() {
+        return paketUpmPackageJson
     }
 
-    void setPaketUpmPackageNames(Map paketUpmPackages) {
-        this.paketUpmPackageNames.set(paketUpmPackages)
+    void setPaketUpmPackageJson(Map paketUpmPackages) {
+        this.paketUpmPackageJson.set(paketUpmPackages)
     }
 
-    void setPaketUpmPackageNames(Provider<Map<String, String>> paketUpmPackages) {
-        this.paketUpmPackageNames.set(paketUpmPackages)
-    }
-
-    void addPaketUpmPackageMapping(String paketName, String upmName) {
-        paketUpmPackageNames.put(paketName, upmName)
-    }
-
-    void addPaketUpmPackageMapping(String paketName, Provider<String> upmName) {
-        paketUpmPackageNames.put(paketName, upmName)
+    void setPaketUpmPackageJson(Provider<Map<String, String>> paketUpmPackages) {
+        this.paketUpmPackageJson.set(paketUpmPackages)
     }
 
     private final Property<Boolean> paketUpmPackageEnabled = objects.property(Boolean)

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUpmPackageSpec.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUpmPackageSpec.groovy
@@ -9,24 +9,25 @@ import org.gradle.api.tasks.Optional
 
 trait PaketUpmPackageSpec implements BaseSpec {
 
-    /**
-     *
-     */
-    private final MapProperty<String, Map<String, Object>> paketUpmPackageJson = objects.mapProperty(String, Map)
+    private final MapProperty<String, Map<String, Object>> paketUpmPackageManifests = objects.mapProperty(String, Map)
 
+    /**
+     * Map [<paket_package_name>: <upm_manifest_contents>] that overrides the contents of generated package.json files in UPM package mode.
+     */
     @Input
     @Optional
-    MapProperty<String, Map<String, Object>> getPaketUpmPackageJson() {
-        return paketUpmPackageJson
+    MapProperty<String, Map<String, Object>> getPaketUpmPackageManifests() {
+        return paketUpmPackageManifests
     }
 
-    void setPaketUpmPackageJson(Map paketUpmPackages) {
-        this.paketUpmPackageJson.set(paketUpmPackages)
+    void setPaketUpmPackageManifests(Map paketUpmPackages) {
+        this.paketUpmPackageManifests.set(paketUpmPackages)
     }
 
-    void setPaketUpmPackageJson(Provider<Map<String, String>> paketUpmPackages) {
-        this.paketUpmPackageJson.set(paketUpmPackages)
+    void setPaketUpmPackageManifests(Provider<Map<String, String>> paketUpmPackages) {
+        this.paketUpmPackageManifests.set(paketUpmPackages)
     }
+
 
     private final Property<Boolean> paketUpmPackageEnabled = objects.property(Boolean)
 
@@ -39,15 +40,14 @@ trait PaketUpmPackageSpec implements BaseSpec {
      * {@code paketUpmPackages} property. If a mapping is not found there,
      * a generic 'com.wooga.nuget.<paket-package-name>' name will be used.
      * <br>
-     * <br>
-     * This mode only works with PackageManagerSystem == paket, and throws otherwise.
-     *
-     * @throws {@code java.lang.IllegalStateException if PackageManagerSystem != paket}
      */
     void enablePaketUpmPackages() {
         paketUpmPackageEnabled.set(true)
     }
 
+    /**
+     * Enables/Disables "UPM package mode" for paket. See {@code PaketUpmPackageSpec::enablePaketUpmPackages} for more details.
+     */
     @Input
     @Optional
     Property<Boolean> getPaketUpmPackageEnabled() {

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUpmPackageSpec.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUpmPackageSpec.groovy
@@ -1,0 +1,73 @@
+package wooga.gradle.paket.unity
+
+import com.wooga.gradle.BaseSpec
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+trait PaketUpmPackageSpec implements BaseSpec {
+
+    private final MapProperty<String, String> paketUpmPackageNames = objects.mapProperty(String, String)
+
+    @Input
+    @Optional
+    MapProperty<String, String> getPaketUpmPackageNames() {
+        return paketUpmPackageNames
+    }
+
+    void setPaketUpmPackageNames(Map paketUpmPackages) {
+        this.paketUpmPackageNames.set(paketUpmPackages)
+    }
+
+    void setPaketUpmPackageNames(Provider<Map<String, String>> paketUpmPackages) {
+        this.paketUpmPackageNames.set(paketUpmPackages)
+    }
+
+    void addPaketUpmPackageMapping(String paketName, String upmName) {
+        paketUpmPackageNames.put(paketName, upmName)
+    }
+
+    void addPaketUpmPackageMapping(String paketName, Provider<String> upmName) {
+        paketUpmPackageNames.put(paketName, upmName)
+    }
+
+    private final Property<Boolean> paketUpmPackageEnabled = objects.property(Boolean)
+
+    /**
+     *
+     * Enables "UPM package mode" for paket. This mode searches for a folder with a 'package.json' in the paket project,
+     * and installs the package in the 'Packages' folder, using the discovered folder as root.
+     * <br>
+     * Non-UPM compatible packages will be given a basic package.json file with a package name described in the
+     * {@code paketUpmPackages} property. If a mapping is not found there,
+     * a generic 'com.wooga.nuget.<paket-package-name>' name will be used.
+     * <br>
+     * <br>
+     * This mode only works with PackageManagerSystem == paket, and throws otherwise.
+     *
+     * @throws {@code java.lang.IllegalStateException if PackageManagerSystem != paket}
+     */
+    void enablePaketUpmPackages() {
+        paketUpmPackageEnabled.set(true)
+    }
+
+    @Input
+    @Optional
+    Property<Boolean> getPaketUpmPackageEnabled() {
+        return paketUpmPackageEnabled
+    }
+
+    Property<Boolean> isPaketUpmPackageEnabled() {
+        return paketUpmPackageEnabled
+    }
+
+    void setPaketUpmPackageEnabled(Boolean enablePaketUpmPackages) {
+        this.paketUpmPackageEnabled.set(enablePaketUpmPackages)
+    }
+
+    void setPaketUpmPackageEnabled(Provider<Boolean> enablePaketUpmPackages) {
+        this.paketUpmPackageEnabled.set(enablePaketUpmPackages)
+    }
+}

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -27,6 +27,8 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
     public static final String DEFAULT_PAKET_UNITY_REFERENCES_FILE_NAME = "paket.unity3d.references"
     public static final String DEFAULT_PAKET_DIRECTORY = "Paket.Unity3D"
+    //This path is relative to the <unityProject>/Assets dir
+    public static final String UNITY_PACKAGES_DIRECTORY = "../Packages"
 
     protected AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
     protected String customPaketOutputDirectory
@@ -44,6 +46,9 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
 
 
     String getPaketOutputDirectoryName() {
+        if(paketUpmPackageEnabled.get()) {
+            return customPaketOutputDirectory ?: UNITY_PACKAGES_DIRECTORY
+        }
         return customPaketOutputDirectory ?: DEFAULT_PAKET_DIRECTORY
     }
 

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/UPMPaketPackage.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/UPMPaketPackage.groovy
@@ -1,5 +1,7 @@
 package wooga.gradle.paket.unity.internal
 
+import groovy.json.JsonOutput
+
 class UPMPaketPackage {
 
     final File baseDir
@@ -16,15 +18,23 @@ class UPMPaketPackage {
         }
     }
 
-    File generateBasicPackageDotJson(String packageName) {
-        return createBasicPackageJson(baseDir, packageName)
+    File writePackageJson(Map<String, Object> contents) {
+        return writePackageJson(baseDir, contents)
     }
 
-    static File createBasicPackageJson(File baseDir, String packageName) {
+    static File writePackageJson(File baseDir, Map<String, Object> contents) {
         def createdPkgJson = new File(baseDir, "package.json")
-        createdPkgJson << UPMPaketPackage.classLoader.getResource("package.json.template")
-                .text.replaceAll("%%UPM_PACKAGE_NAME%%", packageName)
-        return createdPkgJson;
+        createdPkgJson << JsonOutput.prettyPrint(JsonOutput.toJson(contents))
+        return createdPkgJson
+    }
+
+    static Map<String, Object> basicUPMPackageJson(String packageName, Map<String, Object> overrides = [:]) {
+        Map<String, Object> base = [
+                name: packageName,
+                version: "0.0.0"
+        ]
+        base.putAll(overrides)
+        return base
     }
 
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/UPMPaketPackage.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/UPMPaketPackage.groovy
@@ -1,0 +1,30 @@
+package wooga.gradle.paket.unity.internal
+
+class UPMPaketPackage {
+
+    final File baseDir
+    final String name
+
+    UPMPaketPackage(File paketPackageDir) {
+        this.baseDir = paketPackageDir
+        this.name = baseDir.name
+    }
+
+    Optional<File> getPackageDotJson() {
+        return Optional.ofNullable(new File(baseDir, "package.json")).map {
+            it.exists()? it : null
+        }
+    }
+
+    File generateBasicPackageDotJson(String packageName) {
+        return createBasicPackageJson(baseDir, packageName)
+    }
+
+    static File createBasicPackageJson(File baseDir, String packageName) {
+        def createdPkgJson = new File(baseDir, "package.json")
+        createdPkgJson << UPMPaketPackage.classLoader.getResource("package.json.template")
+                .text.replaceAll("%%UPM_PACKAGE_NAME%%", packageName)
+        return createdPkgJson;
+    }
+
+}

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/UPMPaketPackage.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/UPMPaketPackage.groovy
@@ -12,23 +12,23 @@ class UPMPaketPackage {
         this.name = baseDir.name
     }
 
-    Optional<File> getPackageDotJson() {
+    Optional<File> getPackageManifest() {
         return Optional.ofNullable(new File(baseDir, "package.json")).map {
             it.exists()? it : null
         }
     }
 
-    File writePackageJson(Map<String, Object> contents) {
-        return writePackageJson(baseDir, contents)
+    File writePackageManifest(Map<String, Object> contents) {
+        return writePackageManifest(baseDir, contents)
     }
 
-    static File writePackageJson(File baseDir, Map<String, Object> contents) {
+    static File writePackageManifest(File baseDir, Map<String, Object> contents) {
         def createdPkgJson = new File(baseDir, "package.json")
         createdPkgJson << JsonOutput.prettyPrint(JsonOutput.toJson(contents))
         return createdPkgJson
     }
 
-    static Map<String, Object> basicUPMPackageJson(String packageName, Map<String, Object> overrides = [:]) {
+    static Map<String, Object> basicUPMPackageManifest(String packageName, Map<String, Object> overrides = [:]) {
         Map<String, Object> base = [
                 name: packageName,
                 version: "0.0.0"

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -211,10 +211,12 @@ class PaketUnityInstall extends ConventionTask implements PaketUpmPackageSpec {
     protected void createPackageDotJsonIfNotExists(File packageDir) {
         def upmPaket = new UPMPaketPackage(packageDir)
         if(packageDir.exists() && !upmPaket.packageDotJson.present) {
-            def packageName = paketUpmPackageNames.getting(upmPaket.name)
-                    .getOrElse("com.wooga.nuget.${upmPaket.name.toLowerCase()}")
-            upmPaket.generateBasicPackageDotJson(packageName)
-            logger.info("generated package.json ($packageName) for $packageDir")
+
+            def pkgJsonOverrides = paketUpmPackageJson.getting(upmPaket.name).getOrElse([:])
+            def pkgJson = UPMPaketPackage.basicUPMPackageJson("com.wooga.nuget.${upmPaket.name.toLowerCase()}", pkgJsonOverrides)
+
+            upmPaket.writePackageJson(pkgJson)
+            logger.info("generated package.json (${pkgJson['name']}) for $packageDir")
         }
     }
 

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -33,7 +33,11 @@ import org.gradle.api.tasks.incremental.InputFileDetails
 import wooga.gradle.paket.base.utils.internal.PaketLock
 import wooga.gradle.paket.base.utils.internal.PaketUnityReferences
 import wooga.gradle.paket.unity.PaketUnityPlugin
+import wooga.gradle.paket.unity.PaketUpmPackageSpec
 import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
+import wooga.gradle.paket.unity.internal.UPMPaketPackage
+
+import java.nio.file.Paths
 
 /**
  * A task to copy referenced NuGet packages into Unity3D projects.
@@ -50,7 +54,7 @@ import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
  *}*}
  * </pre>
  */
-class PaketUnityInstall extends ConventionTask {
+class PaketUnityInstall extends ConventionTask implements PaketUpmPackageSpec {
 
     /**
      * @return the path to a {@code paket.unity3d.references} file
@@ -122,6 +126,17 @@ class PaketUnityInstall extends ConventionTask {
     PaketUnityInstall() {
         description = 'Copy paket dependencies into unity projects'
         group = PaketUnityPlugin.GROUP
+
+        this.doLast {
+            if (isPaketUpmPackageEnabled().get()) {
+                def references = new PaketUnityReferences(getReferencesFile())
+                def locks = new PaketLock(getLockFile())
+                def packages = locks.getAllDependencies(references.nugets).collect {
+                    new File(outputDirectory, it)
+                }
+                packages.each { createPackageDotJsonIfNotExists(it) }
+            }
+        }
     }
 
     /**
@@ -193,6 +208,16 @@ class PaketUnityInstall extends ConventionTask {
         })
     }
 
+    protected void createPackageDotJsonIfNotExists(File packageDir) {
+        def upmPaket = new UPMPaketPackage(packageDir)
+        if(packageDir.exists() && !upmPaket.packageDotJson.present) {
+            def packageName = paketUpmPackageNames.getting(upmPaket.name)
+                    .getOrElse("com.wooga.nuget.${upmPaket.name.toLowerCase()}")
+            upmPaket.generateBasicPackageDotJson(packageName)
+            logger.info("generated package.json ($packageName) for $packageDir")
+        }
+    }
+
     protected void cleanOutputDirectory() {
         def tree = project.fileTree(getOutputDirectory())
 
@@ -200,6 +225,9 @@ class PaketUnityInstall extends ConventionTask {
         if (getAssemblyDefinitionFileStrategy() == AssemblyDefinitionFileStrategy.manual) {
             tree.exclude("**/*.asmdef")
             tree.exclude("**/*.asmdef.meta")
+        }
+        if(isPaketUpmPackageEnabled().get()) {
+            tree.exclude("manifest.json")
         }
 
         logger.info("delete files in directory: ${getOutputDirectory()}")
@@ -227,7 +255,9 @@ class PaketUnityInstall extends ConventionTask {
         def relativePath = baseDirectory.toURI().relativize(inputFile.toURI()).getPath()
         def pathSegments = relativePath.split("/").toList()
         pathSegments.remove(1)
-        def outputPath = new File(getOutputDirectory(), pathSegments.join(File.separator))
-        outputPath
+        if(isPaketUpmPackageEnabled().get() && inputFile.name in ["package.json", "package.json.meta"]) {
+            return Paths.get(getOutputDirectory().absolutePath, pathSegments[0], inputFile.name).toFile()
+        }
+        return new File(getOutputDirectory(), pathSegments.join(File.separator))
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/tasks/PaketUnityInstall.groovy
@@ -134,7 +134,7 @@ class PaketUnityInstall extends ConventionTask implements PaketUpmPackageSpec {
                 def packages = locks.getAllDependencies(references.nugets).collect {
                     new File(outputDirectory, it)
                 }
-                packages.each { createPackageDotJsonIfNotExists(it) }
+                packages.each { createPackageManifestIfNotExists(it) }
             }
         }
     }
@@ -208,14 +208,14 @@ class PaketUnityInstall extends ConventionTask implements PaketUpmPackageSpec {
         })
     }
 
-    protected void createPackageDotJsonIfNotExists(File packageDir) {
+    protected void createPackageManifestIfNotExists(File packageDir) {
         def upmPaket = new UPMPaketPackage(packageDir)
-        if(packageDir.exists() && !upmPaket.packageDotJson.present) {
+        if(packageDir.exists() && !upmPaket.packageManifest.present) {
 
-            def pkgJsonOverrides = paketUpmPackageJson.getting(upmPaket.name).getOrElse([:])
-            def pkgJson = UPMPaketPackage.basicUPMPackageJson("com.wooga.nuget.${upmPaket.name.toLowerCase()}", pkgJsonOverrides)
+            def pkgJsonOverrides = paketUpmPackageManifests.getting(upmPaket.name).getOrElse([:])
+            def pkgJson = UPMPaketPackage.basicUPMPackageManifest("com.wooga.nuget.${upmPaket.name.toLowerCase()}", pkgJsonOverrides)
 
-            upmPaket.writePackageJson(pkgJson)
+            upmPaket.writePackageManifest(pkgJson)
             logger.info("generated package.json (${pkgJson['name']}) for $packageDir")
         }
     }

--- a/src/main/resources/package.json.template
+++ b/src/main/resources/package.json.template
@@ -1,0 +1,4 @@
+{
+    "name": "%%UPM_PACKAGE_NAME%%",
+    "version": "0.0.0"
+}

--- a/src/main/resources/package.json.template
+++ b/src/main/resources/package.json.template
@@ -1,4 +1,0 @@
-{
-    "name": "%%UPM_PACKAGE_NAME%%",
-    "version": "0.0.0"
-}


### PR DESCRIPTION
## Description
Paket packages can now be configured to be installed as UPM packages. This can be useful when your paket package contains an UPM one (with a `package.json` file), and you want it to be integrated with Unity's packages folder.

This mode sets the installation directory (`paketOutputDirectoryName`) to the unity project's `Packages` folder, and ensures that the `package.json`file for each dependency is in the installed package root.

If an installed package is not UPM-compatible, that is, it doesn't have a `package.json` file, such file will be created. By default, a `package.json` is generated with `com.wooga.nuget.${paketPackage.toLowerCase()}` name, and version `0.0.0`,  but those can be overridden and more properties can be added on using the mappings in `paketUpmPacakgeJson`. 

UPM mode can be enabled through the `paketUpmPackageEnabled` property, or using the `paketUnity.enablePaketUpmPackages()` extension method. It is disabled by default.

## Changes
* ![NEW] Packages can now be installed in UPM mode in paket-unity plugin
* ![ADD] UPM mode in `PaketUnityInstall` task
* ![ADD] `paketUpmPackageEnabled` and `paketUpmPacakgeJson` properties to `PaketUnityPluginExtension`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
