### PR TITLE
Add PAKET_UNITY_ENABLE_UPM_PACKAGE env var

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPlugin.groovy
@@ -59,7 +59,7 @@ class PaketUnityPlugin implements Plugin<Project> {
         createPaketUnityInstallTasks(project, extension)
         createPaketUpmUnwrapTasks(project, extension)
         extension.assemblyDefinitionFileStrategy = PaketUnityPluginConventions.assemblyDefinitionFileStrategy
-        extension.paketUpmPackageEnabled.convention(PaketUnityPluginConventions.paketUpmPackageEnabled)
+        extension.paketUpmPackageEnabled.convention(PaketUnityPluginConventions.paketUpmPackageEnabled.getBooleanValueProvider(project))
 
         project.tasks.matching({ it.name.startsWith("paketUnity")}).configureEach { task ->
             task.onlyIf {

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginConventions.groovy
@@ -1,8 +1,13 @@
 package wooga.gradle.paket.unity
 
+import com.wooga.gradle.PropertyLookup
 import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
 
 class PaketUnityPluginConventions {
      static final AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy = AssemblyDefinitionFileStrategy.disabled
-     static final boolean paketUpmPackageEnabled = false
+     static final PropertyLookup paketUpmPackageEnabled = new PropertyLookup(
+             "PAKET_UNITY_ENABLE_UPM_PACKAGE",
+             "paketUnity.enableUpmPackage",
+             false
+     )
 }


### PR DESCRIPTION
## Description
Adds `PAKET_UNITY_ENABLE_UPM_PACKAGE` boolean environment variable to determine if paket packages should be installed like UPM packages or not. This feature was already present in the `paketUpmPackageEnabled` extension variable.

## Changes
* ![ADD] PAKET_UNITY_ENABLE_UPM_PACKAGE environment variable



[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
