### PR TITLE
Removes paket bootstrap executable from PaketBootstrap task outputs

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/base/tasks/PaketBootstrap.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/PaketBootstrap.groovy
@@ -56,7 +56,7 @@ class PaketBootstrap extends AbstractPaketTask {
 
     @OutputFiles
     FileCollection getOutputFiles() {
-        return project.files(getExecutable(), getPaketExecutable())
+        return project.files(getPaketExecutable())
     }
     
     void setPaketVersion(String value) {


### PR DESCRIPTION
## Description

Fixes a bug detected in UBS, where gradle deletes the `paket.bootstrap.exe` file generated by the `DownloadPaketBootstraper`.

You can reproduce the issue by calling:
```sh
gradlew paketBootstrap #this should run correctly
rm -r .paket
gradlew paketBootstrap #this should fail, accusing that the `paket.bootstrap.exe` file doesn't exists.
# After this, subsequent calls to `paketBootstrap` works as it should, until you delete the `.paket` folder again. 
```
Several tests pointed out that the file is correctly downloaded, but just disappears between the `DownloadPaketBootstraper` and `PaketBootstrap` tasks. This happens because  its set as an output of `PaketBootstrap`. Then in some conditions, gradle wipes out the file, likely to make room to some intended output, making the `PaketBoostrap` task fail. Removing the bootstrap executable from the outputs of `PaketBootstrap` solves the issue, and does not generate any side effects. 


## Changes
* ![FIX] `paket.bootstrap.exe` file missing when `.paket` folder is removed.  



[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
