### PR TITLE
Fix for case-sensitive FS while using paket’s `packages` folder

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketUPMWrapperReference.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketUPMWrapperReference.groovy
@@ -60,9 +60,8 @@ class PaketUPMWrapperReference {
     }
 
     public static String getPackagesDirectory(Project project) {
-        def lowerCasePackages = project.file("packages");
         // this will return "Packages" on case-INsensitive FS and the proper "packages" in case-senitive FS
-        return lowerCasePackages.canonicalFile.name
+        return project.file("packages").canonicalFile.name
     }
 
 }


### PR DESCRIPTION
## Description

getPackagesDirectory() function needs to return the input package cache folder, that paket writes to. 

By default this is small `packages`. However in case we have the unity project on the same level as the main project, then unity also has a `Packages` folder. This exists first, since `packages` is a cache folder and gets created. However on case-insensitive systems it won't get created since it already exists. In this case paket will use `Packages`. 

So the solution is to use File('packages').canonicalFile since that one would return `Packages` in case it's on a case-insensitive FS or `packages` in case it's on a case-insensitive one.

There.... a wall of text explaination for 1 line of code ;) 

## Changes
* ![FIX] broken paketUnityInstall on case-sensitive FS when having a combined unity & main root project

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
