### PR TITLE
Adds provider API for preinstalledUpmPacakges [ATLAS-1463]

### DIFF
--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginExtension.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.paket.unity
 
 import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
 import wooga.gradle.paket.base.PaketPluginExtension
 import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
 
@@ -76,5 +77,16 @@ interface PaketUnityPluginExtension extends PaketPluginExtension, PaketUpmPackag
      * Sets list of pre-installed upm package id's, that should not be modified by the PaketUnityInstall task
      * @param preInstalledPackages
      */
-    void setPreInstalledUpmPackages(List<String> preInstalledPackages);
+    void setPreInstalledUpmPackages(List<String> preInstalledPackages)
+
+    /**
+     * Sets list of pre-installed upm package id's, that should not be modified by the PaketUnityInstall task
+     * @param preInstalledPackages
+     */
+    void setPreInstalledUpmPackages(Provider<List<String>> value)
+
+    /**
+     * @return A list of pre-installed upm package id's, that should not be modified by the PaketUnityInstall task
+     */
+    Provider<List<String>> getPreInstalledUpmPackagesProvider()
 }

--- a/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/internal/DefaultPaketUnityPluginExtension.groovy
@@ -19,6 +19,8 @@ package wooga.gradle.paket.unity.internal
 
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
 import wooga.gradle.paket.base.dependencies.PaketDependencyHandler
 import wooga.gradle.paket.base.internal.DefaultPaketPluginExtension
 import wooga.gradle.paket.unity.PaketUnityPluginExtension
@@ -33,11 +35,11 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
     protected AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy
     protected String customPaketOutputDirectory
     protected Boolean includeAssemblyDefinitions = false
-    protected List<String> preInstalledUpmPackages
+    protected ListProperty<String> preInstalledUpmPackages
 
     DefaultPaketUnityPluginExtension(Project project,final PaketDependencyHandler dependencyHandler) {
         super(project, dependencyHandler)
-        assemblyDefinitionFileStrategy
+        preInstalledUpmPackages = project.objects.listProperty(String)
     }
 
     @Override
@@ -78,15 +80,24 @@ class DefaultPaketUnityPluginExtension extends DefaultPaketPluginExtension imple
     }
 
     @Override
-    List<String> getPreInstalledUpmPackages()
-    {
-        preInstalledUpmPackages
+    List<String> getPreInstalledUpmPackages() {
+        preInstalledUpmPackages.getOrElse([])
     }
 
     @Override
-    void setPreInstalledUpmPackages(List<String> value)
-    {
-        preInstalledUpmPackages = value
+    void setPreInstalledUpmPackages(List<String> value) {
+        preInstalledUpmPackages.set(value)
     }
+
+    @Override
+    void setPreInstalledUpmPackages(Provider<List<String>> value) {
+        preInstalledUpmPackages.set(value)
+    }
+
+    @Override
+    Provider<List<String>> getPreInstalledUpmPackagesProvider() {
+        preInstalledUpmPackages
+    }
+
 
 }


### PR DESCRIPTION
## Description

This just adds an additional way of setting/getting the preinstalled upm packages in the plugin extension using providers.

## Changes
* ![ADD] add provider-based API for set/get PreInstalledUpmPackages


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
