### PR TITLE
Update the default supported frameworks used

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityFrameworksSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/paket/unity/PaketUnityFrameworksSpec.groovy
@@ -32,8 +32,8 @@ class PaketUnityFrameworksSpec extends IntegrationSpec {
         """.stripIndent()
     }
 
-    @Unroll("task:paketUnityInstall wf")
-    def "task:paketUnityInstall with frameworks:#includeFrameworks"() {
+    @Unroll("install #includeFrameworks")
+    def "paket install"() {
         given: "a dependency file with json.net"
         def dependenciesFile = createFile("paket.dependencies")
         dependenciesFile << """
@@ -65,6 +65,7 @@ class PaketUnityFrameworksSpec extends IntegrationSpec {
         includeFrameworks           | excludedFrameworks | dependency        | dependencyVersion
         ["net20"]                   | ["net35", "net46"] | "Newtonsoft.Json" | "11.0.1"
         ["net20", "net35", "net45"] | ["net46"]          | "Newtonsoft.Json" | "11.0.1"
+        ["netstandard2.0"]          | ["net20"]          | "NSubstitute"     | "5.1.0"
 
         frameworksString = includeFrameworks ? "framework: ${includeFrameworks.join(",")}" : ""
     }

--- a/src/main/groovy/wooga/gradle/paket/base/internal/DefaultPaketPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/internal/DefaultPaketPluginExtension.groovy
@@ -28,8 +28,7 @@ class DefaultPaketPluginExtension implements PaketPluginExtension {
     private static final String DEFAULT_PAKET_EXECUTION_NAME = "paket.exe"
     private static final String DEFAULT_PAKET_BOOTSTRAPPER_EXECUTION_NAME = "paket.bootstrapper.exe"
     private static final String DEFAULT_PAKET_DEPENDENCIES_FILE_NAME = "paket.dependencies"
-    private static
-    final String DEFAULT_PAKET_BOOTSTRAPPER_URL = "https://github.com/fsprojects/Paket/releases/download/5.155.0/paket.bootstrapper.exe"
+    private static final String DEFAULT_PAKET_BOOTSTRAPPER_URL = "https://github.com/fsprojects/Paket/releases/download/5.155.0/paket.bootstrapper.exe"
 
     private static final String DEFAULT_VERSION = ""
     private static final String DEFAULT_MONO_EXECUTABLE = "mono"

--- a/src/main/groovy/wooga/gradle/paket/base/tasks/PaketDependenciesTask.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/tasks/PaketDependenciesTask.groovy
@@ -34,6 +34,9 @@ import wooga.gradle.paket.base.repository.NugetArtifactRepository
 
 import java.nio.file.Path
 
+/***
+ * This task generates a `paket.dependencies` file.
+ */
 class PaketDependenciesTask extends DefaultTask {
 
     protected final PaketDependencyConfigurationContainer configurationContainer

--- a/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketDependencies.groovy
+++ b/src/main/groovy/wooga/gradle/paket/base/utils/internal/PaketDependencies.groovy
@@ -17,10 +17,9 @@
 
 package wooga.gradle.paket.base.utils.internal
 
-class PaketDependencies implements wooga.gradle.paket.base.utils.PaketDependencies{
+import wooga.gradle.paket.unity.PaketUnityPluginConventions
 
-    final private List<String> DEFAULT_FRAMEWORKS = ["net11", "net20", "net35", "unity", "net35-unity full v3.5", "net35-unity subset v3.5"]
-    // 4.6 -> ["net462", "net461", "net46", "net452", "net451", "net45", "net403", "net40", "net4"]
+class PaketDependencies implements wooga.gradle.paket.base.utils.PaketDependencies {
 
     PaketDependencies(File dependenciesFile) {
         this(dependenciesFile.text)
@@ -65,6 +64,6 @@ class PaketDependencies implements wooga.gradle.paket.base.utils.PaketDependenci
     }
 
     List<String> getFrameworks() {
-        frameworks ?: DEFAULT_FRAMEWORKS
+        frameworks ?: PaketUnityPluginConventions.defaultFrameworks
     }
 }

--- a/src/main/groovy/wooga/gradle/paket/get/tasks/PaketInstall.groovy
+++ b/src/main/groovy/wooga/gradle/paket/get/tasks/PaketInstall.groovy
@@ -21,7 +21,8 @@ import wooga.gradle.paket.internal.PaketCommand
 import wooga.gradle.paket.base.tasks.internal.AbstractPaketTask
 
 /**
- * A task to invoke {@code paket install} command.
+ * A task to invoke {@code paket install} command, which
+ * Compute dependency graph, download dependencies and update projects.
  */
 class PaketInstall extends AbstractPaketTask {
 

--- a/src/main/groovy/wooga/gradle/paket/get/tasks/PaketOutdated.groovy
+++ b/src/main/groovy/wooga/gradle/paket/get/tasks/PaketOutdated.groovy
@@ -22,6 +22,7 @@ import wooga.gradle.paket.base.tasks.internal.AbstractPaketTask
 
 /**
  * A task to invoke {@code paket outdated} command.
+ * Find dependencies that have newer versions available.
  */
 class PaketOutdated extends AbstractPaketTask {
 

--- a/src/main/groovy/wooga/gradle/paket/get/tasks/PaketRestore.groovy
+++ b/src/main/groovy/wooga/gradle/paket/get/tasks/PaketRestore.groovy
@@ -25,6 +25,8 @@ import wooga.gradle.paket.internal.PaketCommand
 
 /**
  * A task to invoke {@code paket restore} command.
+ * Download the computed dependency graph.
+ * Note that this fails with an error if the `paket.lock` file does not exist.
  */
 class PaketRestore extends AbstractPaketTask {
 

--- a/src/main/groovy/wooga/gradle/paket/get/tasks/PaketUpdate.groovy
+++ b/src/main/groovy/wooga/gradle/paket/get/tasks/PaketUpdate.groovy
@@ -24,6 +24,8 @@ import wooga.gradle.paket.base.tasks.internal.AbstractPaketTask
 
 /**
  * A task to invoke {@code paket update} command.
+ * Update dependencies to their latest version.
+ * If you do not specify a package, then all packages from paket.dependencies are updated.
  */
 class PaketUpdate extends AbstractPaketTask {
 

--- a/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
+++ b/src/main/groovy/wooga/gradle/paket/pack/tasks/PaketPack.groovy
@@ -26,6 +26,7 @@ import java.util.concurrent.Callable
 
 /**
  * A task to invoke {@code paket pack} command with given {@code paket.template} file.
+ * Create NuGet packages from paket.template files.
  * <p>
  * Example:
  * <pre>

--- a/src/main/groovy/wooga/gradle/paket/publish/tasks/PaketPush.groovy
+++ b/src/main/groovy/wooga/gradle/paket/publish/tasks/PaketPush.groovy
@@ -26,6 +26,7 @@ import java.util.concurrent.Callable
 
 /**
  * A task to invoke {@code paket push} command with given {@code .nupgk} file.
+ * Push a NuGet package.
  * <p>
  * Example:
  * <pre>

--- a/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/paket/unity/PaketUnityPluginConventions.groovy
@@ -4,10 +4,23 @@ import com.wooga.gradle.PropertyLookup
 import wooga.gradle.paket.unity.internal.AssemblyDefinitionFileStrategy
 
 class PaketUnityPluginConventions {
+
+     /**
+      * Default strategy for handling the assembly definition files
+      */
      static final AssemblyDefinitionFileStrategy assemblyDefinitionFileStrategy = AssemblyDefinitionFileStrategy.disabled
+
+     /**
+      * Whetehr to enable upm package support
+      */
      static final PropertyLookup paketUpmPackageEnabled = new PropertyLookup(
              "PAKET_UNITY_ENABLE_UPM_PACKAGE",
              "paketUnity.enableUpmPackage",
              false
      )
+
+     /**
+      * Default NET frameworks that are to be installed onto the target directory
+      */
+     static final List<String> defaultFrameworks = ["net11", "net20", "net35", "net45", "netstandard2.0"]
 }

--- a/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketDependenciesSpec.groovy
+++ b/src/test/groovy/wooga/gradle/paket/base/utils/internal/PaketDependenciesSpec.groovy
@@ -59,6 +59,16 @@ class PaketDependenciesSpec extends Specification {
         http http://www.fssnip.net/1n decrypt.fs
     """.stripIndent()
 
+
+    static String NETSTANDARD_2_CONTENT = """
+source https://nuget.org/api/v2
+nuget NSubstitute == 1.9.2
+framework: netstandard2.0
+
+nuget Wooga.TestSupport >= 3.4.0
+nuget Wooga.SbsSchurle >= 0.1.1
+    """.stripIndent()
+
     @Shared
     File dependenciesFile = File.createTempFile("paket", ".dependencies")
 
@@ -131,14 +141,16 @@ class PaketDependenciesSpec extends Specification {
 
         then:
         def frameworks = dependencies.frameworks
-        frameworks.size() == 2
-        frameworks.contains("net35")
-        frameworks.contains("net40")
+        frameworks.size() == expected.size()
+        expected.forEach({
+            frameworks.contains(it)
+        })
 
         where:
-        objectType | content
-        "String"   | DEPENDENCIES_CONTENT
-        "File"     | dependenciesFile << DEPENDENCIES_CONTENT
+        objectType | expected           | content
+        "String"   | ["net35", "net40"] | DEPENDENCIES_CONTENT
+        "File"     | ["net35", "net40"] | dependenciesFile << DEPENDENCIES_CONTENT
+        "String"   | ["netstandard2.0"] | NETSTANDARD_2_CONTENT
     }
 
     @Unroll


### PR DESCRIPTION
## Description

Add support for `netstandard2.0` as a default framework. Update comments on the tasks for a bit more clarity.

## Changes
* ![UPDATE] Default framework versions, removing deprecated unity-specific ones, now bringing NET Standard 2.
* ![IMPROVE] Comments on the tasks

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
